### PR TITLE
Fix for sherlock issues 111, 79, 27

### DIFF
--- a/src/HSGLib.sol
+++ b/src/HSGLib.sol
@@ -76,3 +76,7 @@ error SignersCannotChangeOwners();
 /// @notice Emmitted when a call to `checkTransaction` or `checkAfterExecution` is not made from the `safe`
 /// @dev Together with `guardEntries`, protects against arbitrary reentrancy attacks by the signers
 error NotCalledFromSafe();
+
+/// @notice Emmitted when attempting to reenter `checkTransaction`
+/// @dev The Safe will catch this error and re-throw with its own error message (`GS013`)
+error NoReentryAllowed();

--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0
 pragma solidity >=0.8.13;
 
-import { Test, console2 } from "forge-std/Test.sol"; // remove after testing
+// import { Test, console2 } from "forge-std/Test.sol"; // remove after testing
 import { HatsSignerGateBase, IGnosisSafe, Enum } from "./HatsSignerGateBase.sol";
 import "./HSGLib.sol";
 
@@ -72,8 +72,6 @@ contract HatsSignerGate is HatsSignerGateBase {
     /// @param _account The address to check
     /// @return valid Whether `_account` is a valid signer
     function isValidSigner(address _account) public view override returns (bool valid) {
-        // console2.log("ivs 1");
         valid = HATS.isWearerOfHat(_account, signersHatId);
-        // console2.log("ivs 2");
     }
 }

--- a/src/HatsSignerGateBase.sol
+++ b/src/HatsSignerGateBase.sol
@@ -107,9 +107,14 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
     }
 
     /// @notice Internal function to set the target threshold
-    /// @dev Reverts if `_targetThreshold` is greater than `maxSigners`
+    /// @dev Reverts if `_targetThreshold` is greater than `maxSigners` or lower than `minThreshold`
     /// @param _targetThreshold The new target threshold to set
     function _setTargetThreshold(uint256 _targetThreshold) internal {
+        // target threshold cannot be lower than min threshold
+        if (_targetThreshold < minThreshold) {
+            revert InvalidTargetThreshold();
+        }
+        // target threshold cannot be greater than max signers
         if (_targetThreshold > maxSigners) {
             revert InvalidTargetThreshold();
         }

--- a/src/HatsSignerGateBase.sol
+++ b/src/HatsSignerGateBase.sol
@@ -425,14 +425,12 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
         address // msgSender
     ) external override {
         if (msg.sender != address(safe)) revert NotCalledFromSafe();
-
         // get the safe owners
         address[] memory owners = safe.getOwners();
         {
             // scope to avoid stack too deep errors
             uint256 safeOwnerCount = owners.length;
             // uint256 validSignerCount = _countValidSigners(safe.getOwners());
-
             // ensure that safe threshold is correct
             reconcileSignerCount();
 
@@ -440,7 +438,6 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
                 revert BelowMinThreshold(minThreshold, safeOwnerCount);
             }
         }
-
         // get the tx hash; view function
         bytes32 txHash = safe.getTransactionHash(
             // Transaction info
@@ -472,6 +469,8 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
         unchecked {
             ++_guardEntries;
         }
+        // revert if re-entry is detected
+        if (_guardEntries > 1) revert NoReentryAllowed();
     }
 
     /**
@@ -517,7 +516,7 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
         else if (modulesWith1[0] != address(this)) {
             revert SignersCannotChangeModules();
         }
-        // leave checked to catch underflows triggered by re-erntry attempts
+        // leave checked to catch underflows triggered by re-entry attempts
         --_guardEntries;
     }
 

--- a/src/HatsSignerGateBase.sol
+++ b/src/HatsSignerGateBase.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0
 pragma solidity >=0.8.13;
 
-import { Test, console2 } from "forge-std/Test.sol"; // remove after testing
+// import { Test, console2 } from "forge-std/Test.sol"; // remove after testing
 import "./HSGLib.sol";
 import { HatsOwnedInitializable } from "hats-auth/HatsOwnedInitializable.sol";
 import { BaseGuard } from "zodiac/guard/BaseGuard.sol";
@@ -22,9 +22,6 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
 
     /// @notice The maximum number of signers allowed for the `safe`
     uint256 public maxSigners;
-
-    // /// @notice The current number of signers on the `safe`
-    // uint256 public signerCount;
 
     /// @notice The version of HatsSignerGate used in this contract
     string public version;
@@ -125,7 +122,6 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
     /// @param _signerCount The number of valid signers on the `safe`; should be calculated from `validSignerCount()`
     function _setSafeThreshold(uint256 _threshold, uint256 _signerCount) internal {
         uint256 newThreshold = _threshold;
-        // uint256 signerCount = validSignerCount();
 
         // ensure that txs can't execute if fewer signers than target threshold
         if (_signerCount <= _threshold) {
@@ -200,6 +196,8 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
         }
     }
 
+    /// @notice Tallies the number of existing `safe` owners that wear a signer hat
+    /// @return signerCount The number of valid signers on the `safe`
     function validSignerCount() public view returns (uint256 signerCount) {
         signerCount = _countValidSigners(safe.getOwners());
     }

--- a/src/HatsSignerGateBase.sol
+++ b/src/HatsSignerGateBase.sol
@@ -458,11 +458,11 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
             // We subtract 1 since nonce was just incremented in the parent function call
             safe.nonce() - 1 // view function
         );
-
-        uint256 validSigCount = countValidSignatures(txHash, signatures, signatures.length / 65);
+        uint256 threshold = safe.getThreshold();
+        uint256 validSigCount = countValidSignatures(txHash, signatures, threshold);
 
         // revert if there aren't enough valid signatures
-        if (validSigCount < safe.getThreshold() || validSigCount < minThreshold) {
+        if (validSigCount < threshold || validSigCount < minThreshold) {
             revert InvalidSigners();
         }
 

--- a/src/HatsSignerGateBase.sol
+++ b/src/HatsSignerGateBase.sol
@@ -295,7 +295,7 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
         address ownerToCheck;
         bytes memory data;
 
-        for (uint256 i; i < _ownerCount - 1;) {
+        for (uint256 i; i < _ownerCount;) {
             ownerToCheck = _owners[i];
 
             if (!isValidSigner(ownerToCheck)) {

--- a/src/HatsSignerGateBase.sol
+++ b/src/HatsSignerGateBase.sol
@@ -207,7 +207,7 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
             newThreshold = target;
         }
         if (newThreshold > 0) {
-            bytes memory data = abi.encodeWithSignature("changeThreshold(uint256)", signerCount);
+            bytes memory data = abi.encodeWithSignature("changeThreshold(uint256)", newThreshold);
 
             bool success = safe.execTransactionFromModule(
                 address(safe), // to

--- a/src/HatsSignerGateBase.sol
+++ b/src/HatsSignerGateBase.sol
@@ -99,7 +99,8 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
         if (_targetThreshold != targetThreshold) {
             _setTargetThreshold(_targetThreshold);
 
-            if (validSignerCount() > 1) _setSafeThreshold(_targetThreshold);
+            uint256 signerCount = validSignerCount();
+            if (signerCount > 1) _setSafeThreshold(_targetThreshold, signerCount);
 
             emit HSGLib.TargetThresholdSet(_targetThreshold);
         }
@@ -119,13 +120,14 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
     /// @notice Internal function to set the threshold for the `safe`
     /// @dev Forwards the threshold-setting call to `safe.ExecTransactionFromModule`
     /// @param _threshold The threshold to set on the `safe`
-    function _setSafeThreshold(uint256 _threshold) internal {
+    /// @param _signerCount The number of valid signers on the `safe`; should be calculated from `validSignerCount()`
+    function _setSafeThreshold(uint256 _threshold, uint256 _signerCount) internal {
         uint256 newThreshold = _threshold;
-        uint256 signerCount = validSignerCount();
+        // uint256 signerCount = validSignerCount();
 
         // ensure that txs can't execute if fewer signers than target threshold
-        if (signerCount <= _threshold) {
-            newThreshold = signerCount;
+        if (_signerCount <= _threshold) {
+            newThreshold = _signerCount;
         }
         if (newThreshold != safe.getThreshold()) {
             bytes memory data = abi.encodeWithSignature("changeThreshold(uint256)", newThreshold);

--- a/src/HatsSignerGateFactory.sol
+++ b/src/HatsSignerGateFactory.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0
 pragma solidity >=0.8.13;
 
-import { console2 } from "forge-std/Test.sol"; // remove after testing
+// import { console2 } from "forge-std/Test.sol"; // remove after testing
 import "./HatsSignerGate.sol";
 import "./MultiHatsSignerGate.sol";
 import "@gnosis.pm/safe-contracts/contracts/GnosisSafe.sol";

--- a/src/MultiHatsSignerGate.sol
+++ b/src/MultiHatsSignerGate.sol
@@ -40,7 +40,8 @@ contract MultiHatsSignerGate is HatsSignerGateBase {
     /// @param _hatId The hat id to claim signer rights for
     function claimSigner(uint256 _hatId) public {
         uint256 maxSigs = maxSigners; // save SLOADs
-        uint256 currentSignerCount = signerCount;
+        address[] memory owners = safe.getOwners();
+        uint256 currentSignerCount = _countValidSigners(owners);
 
         if (currentSignerCount >= maxSigs) {
             revert MaxSignersReached();
@@ -63,11 +64,10 @@ contract MultiHatsSignerGate is HatsSignerGateBase {
         If we're already at maxSigners, we'll replace one of the invalid owners by swapping the signer.
         Otherwise, we'll simply add the new signer.
         */
-        address[] memory owners = safe.getOwners();
         uint256 ownerCount = owners.length;
 
         if (ownerCount >= maxSigs) {
-            bool swapped = _swapSigner(owners, ownerCount, maxSigs, currentSignerCount, msg.sender);
+            bool swapped = _swapSigner(owners, ownerCount, msg.sender);
             if (!swapped) {
                 // if there are no invalid owners, we can't add a new signer, so we revert
                 revert NoInvalidSignersToReplace();

--- a/test/HSGFactoryTestSetup.t.sol
+++ b/test/HSGFactoryTestSetup.t.sol
@@ -124,4 +124,9 @@ contract HSGFactoryTestSetup is Test {
             abi.encode(from, bytes32(0), bytes1(0x01))
         );
     }
+
+    function mockIsWearerCall(address wearer, uint256 hat, bool result) public {
+        bytes memory data = abi.encodeWithSignature("isWearerOfHat(address,uint256)", wearer, hat);
+        vm.mockCall(HATS, data, abi.encode(result));
+    }
 }

--- a/test/HSGFactoryTestSetup.t.sol
+++ b/test/HSGFactoryTestSetup.t.sol
@@ -89,4 +89,39 @@ contract HSGFactoryTestSetup is Test {
         _multiHatsSignerGate = MultiHatsSignerGate(mhsg);
         _safe = GnosisSafe(payable(safe_));
     }
+
+    // borrowed from Orca (https://github.com/orcaprotocol/contracts/blob/main/contracts/utils/SafeTxHelper.sol)
+    function getSafeTxHash(address to, bytes memory data, GnosisSafe _safe) public view returns (bytes32 txHash) {
+        return _safe.getTransactionHash(
+            to,
+            0,
+            data,
+            Enum.Operation.Call,
+            // not using the refunder
+            0,
+            0,
+            0,
+            address(0),
+            payable(address(0)),
+            safe.nonce()
+        );
+    }
+
+    // modified from Orca (https://github.com/orcaprotocol/contracts/blob/main/contracts/utils/SafeTxHelper.sol)
+    function executeSafeTxFrom(address from, bytes memory data, GnosisSafe _safe) public {
+        safe.execTransaction(
+            address(_safe),
+            0,
+            data,
+            Enum.Operation.Call,
+            // not using the refunder
+            0,
+            0,
+            0,
+            address(0),
+            payable(address(0)),
+            // (r,s,v) [r - from] [s - unused] [v - 1 flag for onchain approval]
+            abi.encode(from, bytes32(0), bytes1(0x01))
+        );
+    }
 }

--- a/test/HSGTestSetup.t.sol
+++ b/test/HSGTestSetup.t.sol
@@ -44,6 +44,7 @@ contract HSGTestSetup is HSGFactoryTestSetup, SignatureDecoder {
         );
 
         (hatsSignerGate, safe) = deployHSGAndSafe(ownerHat, signerHat, minThreshold, targetThreshold, maxSigners);
+        mockIsWearerCall(address(hatsSignerGate), signerHat, false);
     }
 
     //// HELPER FUNCTIONS ////

--- a/test/HSGTestSetup.t.sol
+++ b/test/HSGTestSetup.t.sol
@@ -60,11 +60,6 @@ contract HSGTestSetup is HSGFactoryTestSetup, SignatureDecoder {
         }
     }
 
-    function mockIsWearerCall(address wearer, uint256 hat, bool result) public {
-        bytes memory data = abi.encodeWithSignature("isWearerOfHat(address,uint256)", wearer, hat);
-        vm.mockCall(HATS, data, abi.encode(result));
-    }
-
     function getEthTransferSafeTxHash(address to, uint256 value, GnosisSafe _safe)
         public
         view

--- a/test/HSGTestSetup.t.sol
+++ b/test/HSGTestSetup.t.sol
@@ -65,41 +65,6 @@ contract HSGTestSetup is HSGFactoryTestSetup, SignatureDecoder {
         vm.mockCall(HATS, data, abi.encode(result));
     }
 
-    // modified from Orca (https://github.com/orcaprotocol/contracts/blob/main/contracts/utils/SafeTxHelper.sol)
-    function executeSafeTxFrom(address from, bytes memory data, GnosisSafe _safe) public {
-        safe.execTransaction(
-            address(_safe),
-            0,
-            data,
-            Enum.Operation.Call,
-            // not using the refunder
-            0,
-            0,
-            0,
-            address(0),
-            payable(address(0)),
-            // (r,s,v) [r - from] [s - unused] [v - 1 flag for onchain approval]
-            abi.encode(from, bytes32(0), bytes1(0x01))
-        );
-    }
-
-    // borrowed from Orca (https://github.com/orcaprotocol/contracts/blob/main/contracts/utils/SafeTxHelper.sol)
-    function getSafeTxHash(address to, bytes memory data, GnosisSafe _safe) public view returns (bytes32 txHash) {
-        return _safe.getTransactionHash(
-            to,
-            0,
-            data,
-            Enum.Operation.Call,
-            // not using the refunder
-            0,
-            0,
-            0,
-            address(0),
-            payable(address(0)),
-            safe.nonce()
-        );
-    }
-
     function getEthTransferSafeTxHash(address to, uint256 value, GnosisSafe _safe)
         public
         view

--- a/test/HatsSignerGate.t.sol
+++ b/test/HatsSignerGate.t.sol
@@ -1141,7 +1141,8 @@ contract HatsSignerGateTest is HSGTestSetup {
         // 1) craft the addOwner action
         // mock the new owner as a valid signer
         mockIsWearerCall(newOwner, signerHat, true);
-        { // use scope to avoid stack too deep error
+        {
+            // use scope to avoid stack too deep error
             // compile the action
             addOwnerAction = abi.encodeWithSignature("addOwnerWithThreshold(address,uint256)", newOwner, 2);
 

--- a/test/HatsSignerGate.t.sol
+++ b/test/HatsSignerGate.t.sol
@@ -1010,6 +1010,20 @@ contract HatsSignerGateTest is HSGTestSetup {
         assertEq(hatsSignerGate.validSignerCount(), 5, "valid signer count");
     }
 
+    function testSetTargetThresholdUpdatesThresholdCorrectly() public {
+        // set target threshold to 5
+        mockIsWearerCall(address(this), ownerHat, true);
+        hatsSignerGate.setTargetThreshold(5);
+        // add 5 valid signers
+        addSigners(5);
+        // one loses their hat
+        mockIsWearerCall(addresses[4], signerHat, false);
+        // lower target threshold to 4
+        hatsSignerGate.setTargetThreshold(4);
+        // since hatsSignerGate.validSignerCount() is also 4, the threshold should also be 4
+        assertEq(safe.getThreshold(), 4, "threshold");
+    }
+
     // function testSignersCannotChangeModules() public {
     //     //
     // }

--- a/test/HatsSignerGate.t.sol
+++ b/test/HatsSignerGate.t.sol
@@ -827,48 +827,10 @@ contract HatsSignerGateTest is HSGTestSetup {
     }
 
     function testSignersCannotAddNewModules() public {
-        bytes memory addModuleData = abi.encodeWithSignature("enableModule(address)", address(0xf00baa)); // some devs are from Boston
-
-        addSigners(2);
-
-        bytes32 txHash = getTxHash(address(safe), 0, addModuleData, safe);
-
-        bytes memory signatures = createNSigsForTx(txHash, 2);
-
-        mockIsWearerCall(addresses[0], signerHat, true);
-        mockIsWearerCall(addresses[1], signerHat, true);
-
-        vm.expectRevert(SignersCannotChangeModules.selector);
-
-        // execute tx
-        safe.execTransaction(
-            address(safe),
-            0,
-            addModuleData,
-            Enum.Operation.Call,
-            // not using the refunder
-            0,
-            0,
-            0,
-            address(0),
-            payable(address(0)),
-            signatures
-        );
-    }
-
-    function testOwnerCanAddNewModule() public {
-        mockIsWearerCall(address(this), ownerHat, true);
-        hatsSignerGate.enableNewModule(address(0xf00baa));
-
-        assertEq(hatsSignerGate.enabledModuleCount(), 2);
-    }
-
-    function testSignersCannotAddNewModulesWithExistingEnabledModule() public {
-        mockIsWearerCall(address(this), ownerHat, true);
-        hatsSignerGate.enableNewModule(address(0xdec1a551f1ed));
-
-        assertEq(hatsSignerGate.enabledModuleCount(), 2);
-
+        (address[] memory modules, ) = safe.getModulesPaginated(SENTINELS, 5);
+        console2.log(modules.length);
+        // console2.log(modules[1]);
+        
         bytes memory addModuleData = abi.encodeWithSignature("enableModule(address)", address(0xf00baa)); // some devs are from Boston
 
         addSigners(2);

--- a/test/HatsSignerGate.t.sol
+++ b/test/HatsSignerGate.t.sol
@@ -826,6 +826,24 @@ contract HatsSignerGateTest is HSGTestSetup {
         hatsSignerGate.claimSigner();
     }
 
+    function testValidSignersCanClaimAfterLastMaxSignerLosesHat() public {
+        // max signers is 5
+        // 5 signers claim
+        addSigners(5);
+
+        address[] memory owners = safe.getOwners();
+
+        // a signer misbehaves and loses the hat
+        mockIsWearerCall(owners[4], signerHat, false);
+
+        // validSignerCount is now 4
+        assertEq(hatsSignerGate.validSignerCount(), 4);
+
+        mockIsWearerCall(addresses[5], signerHat, true);
+        vm.prank(addresses[5]);
+        hatsSignerGate.claimSigner();
+    }
+
     function testSignersCannotAddNewModules() public {
         (address[] memory modules,) = safe.getModulesPaginated(SENTINELS, 5);
         console2.log(modules.length);

--- a/test/HatsSignerGate.t.sol
+++ b/test/HatsSignerGate.t.sol
@@ -1024,6 +1024,16 @@ contract HatsSignerGateTest is HSGTestSetup {
         assertEq(safe.getThreshold(), 4, "threshold");
     }
 
+    function testSetTargetTresholdCannotSetBelowMinThreshold() public {
+        assertEq(hatsSignerGate.minThreshold(), 2, "min threshold");
+        assertEq(hatsSignerGate.targetThreshold(), 2, "target threshold");
+
+        // set target threshold to 1 — should fail
+        mockIsWearerCall(address(this), ownerHat, true);
+        vm.expectRevert(InvalidTargetThreshold.selector);
+        hatsSignerGate.setTargetThreshold(1);
+    }
+
     // function testSignersCannotChangeModules() public {
     //     //
     // }

--- a/test/HatsSignerGate.t.sol
+++ b/test/HatsSignerGate.t.sol
@@ -827,10 +827,10 @@ contract HatsSignerGateTest is HSGTestSetup {
     }
 
     function testSignersCannotAddNewModules() public {
-        (address[] memory modules, ) = safe.getModulesPaginated(SENTINELS, 5);
+        (address[] memory modules,) = safe.getModulesPaginated(SENTINELS, 5);
         console2.log(modules.length);
         // console2.log(modules[1]);
-        
+
         bytes memory addModuleData = abi.encodeWithSignature("enableModule(address)", address(0xf00baa)); // some devs are from Boston
 
         addSigners(2);

--- a/test/HatsSignerGate.t.sol
+++ b/test/HatsSignerGate.t.sol
@@ -83,6 +83,9 @@ contract HatsSignerGateTest is HSGTestSetup {
     }
 
     function testReconcileSignerCount() public {
+        mockIsWearerCall(addresses[1], signerHat, false);
+        mockIsWearerCall(addresses[2], signerHat, false);
+        mockIsWearerCall(addresses[3], signerHat, false);
         // add 3 more safe owners the old fashioned way
         // 1
         bytes memory addOwnersData1 = abi.encodeWithSignature("addOwnerWithThreshold(address,uint256)", addresses[1], 1);
@@ -123,18 +126,16 @@ contract HatsSignerGateTest is HSGTestSetup {
             Enum.Operation.Call // operation
         );
 
-        assertEq(hatsSignerGate.signerCount(), 0);
+        assertEq(hatsSignerGate.validSignerCount(), 0);
 
         // set only two of them as valid signers
         mockIsWearerCall(address(hatsSignerGate), signerHat, true);
         mockIsWearerCall(addresses[1], signerHat, true);
-        mockIsWearerCall(addresses[2], signerHat, false);
-        mockIsWearerCall(addresses[3], signerHat, false);
 
         // do the reconcile
         hatsSignerGate.reconcileSignerCount();
 
-        assertEq(hatsSignerGate.signerCount(), 2);
+        assertEq(hatsSignerGate.validSignerCount(), 2);
         assertEq(safe.getThreshold(), 2);
 
         // now we can remove both the invalid signers with no changes to hatsSignerCount
@@ -143,7 +144,7 @@ contract HatsSignerGateTest is HSGTestSetup {
         mockIsWearerCall(addresses[3], signerHat, false);
         hatsSignerGate.removeSigner(addresses[3]);
 
-        assertEq(hatsSignerGate.signerCount(), 2);
+        assertEq(hatsSignerGate.validSignerCount(), 2);
         assertEq(safe.getThreshold(), 2);
     }
 
@@ -152,7 +153,7 @@ contract HatsSignerGateTest is HSGTestSetup {
 
         assertEq(safe.getOwners().length, 1);
 
-        assertEq(hatsSignerGate.signerCount(), 1);
+        assertEq(hatsSignerGate.validSignerCount(), 1);
 
         assertEq(safe.getOwners()[0], addresses[0]);
 
@@ -162,7 +163,7 @@ contract HatsSignerGateTest is HSGTestSetup {
     function testAddThreeSigners() public {
         addSigners(3);
 
-        assertEq(hatsSignerGate.signerCount(), 3);
+        assertEq(hatsSignerGate.validSignerCount(), 3);
 
         assertEq(safe.getOwners()[0], addresses[2]);
         assertEq(safe.getOwners()[1], addresses[1]);
@@ -182,7 +183,7 @@ contract HatsSignerGateTest is HSGTestSetup {
         // this call should fail
         hatsSignerGate.claimSigner();
 
-        assertEq(hatsSignerGate.signerCount(), 5);
+        assertEq(hatsSignerGate.validSignerCount(), 5);
 
         assertEq(safe.getOwners()[0], addresses[4]);
         assertEq(safe.getOwners()[1], addresses[3]);
@@ -213,7 +214,7 @@ contract HatsSignerGateTest is HSGTestSetup {
 
         hatsSignerGate.claimSigner();
 
-        assertEq(hatsSignerGate.signerCount(), 2);
+        assertEq(hatsSignerGate.validSignerCount(), 2);
     }
 
     function testNonHatWearerCannotClaimSigner() public {
@@ -234,7 +235,7 @@ contract HatsSignerGateTest is HSGTestSetup {
 
         assertEq(safe.getOwners().length, 1);
         assertEq(safe.getOwners()[0], address(hatsSignerGate));
-        assertEq(hatsSignerGate.signerCount(), 0);
+        assertEq(hatsSignerGate.validSignerCount(), 0);
 
         assertEq(safe.getThreshold(), 1);
     }
@@ -250,7 +251,7 @@ contract HatsSignerGateTest is HSGTestSetup {
 
         assertEq(safe.getOwners().length, 1);
         assertEq(safe.getOwners()[0], addresses[1]);
-        assertEq(hatsSignerGate.signerCount(), 1);
+        assertEq(hatsSignerGate.validSignerCount(), 1);
 
         assertEq(safe.getThreshold(), 1);
     }
@@ -261,13 +262,13 @@ contract HatsSignerGateTest is HSGTestSetup {
         mockIsWearerCall(addresses[0], signerHat, false);
 
         hatsSignerGate.reconcileSignerCount();
-        assertEq(hatsSignerGate.signerCount(), 1);
+        assertEq(hatsSignerGate.validSignerCount(), 1);
 
         hatsSignerGate.removeSigner(addresses[0]);
 
         assertEq(safe.getOwners().length, 1);
         assertEq(safe.getOwners()[0], addresses[1]);
-        assertEq(hatsSignerGate.signerCount(), 1);
+        assertEq(hatsSignerGate.validSignerCount(), 1);
 
         assertEq(safe.getThreshold(), 1);
     }
@@ -278,14 +279,14 @@ contract HatsSignerGateTest is HSGTestSetup {
         mockIsWearerCall(addresses[0], signerHat, false);
 
         hatsSignerGate.reconcileSignerCount();
-        assertEq(hatsSignerGate.signerCount(), 2);
+        assertEq(hatsSignerGate.validSignerCount(), 2);
 
         hatsSignerGate.removeSigner(addresses[0]);
 
         assertEq(safe.getOwners().length, 2);
         assertEq(safe.getOwners()[0], addresses[2]);
         assertEq(safe.getOwners()[1], addresses[1]);
-        assertEq(hatsSignerGate.signerCount(), 2);
+        assertEq(hatsSignerGate.validSignerCount(), 2);
 
         assertEq(safe.getThreshold(), 2);
     }
@@ -301,7 +302,7 @@ contract HatsSignerGateTest is HSGTestSetup {
 
         assertEq(safe.getOwners().length, 1);
         assertEq(safe.getOwners()[0], addresses[0]);
-        assertEq(hatsSignerGate.signerCount(), 1);
+        assertEq(hatsSignerGate.validSignerCount(), 1);
 
         assertEq(safe.getThreshold(), 1);
     }
@@ -735,13 +736,13 @@ contract HatsSignerGateTest is HSGTestSetup {
 
         // reconcile is called, so signerCount is updated to 4
         hatsSignerGate.reconcileSignerCount();
-        assertEq(hatsSignerGate.signerCount(), 4);
+        assertEq(hatsSignerGate.validSignerCount(), 4);
 
         // a new signer claims, so signerCount is updated to 5
         mockIsWearerCall(addresses[5], signerHat, true);
         vm.prank(addresses[5]);
         hatsSignerGate.claimSigner();
-        assertEq(hatsSignerGate.signerCount(), 5);
+        assertEq(hatsSignerGate.validSignerCount(), 5);
 
         // the malicious signer behaves nicely and regains the hat, but they were kicked out by the previous signer claim
         mockIsWearerCall(addresses[4], signerHat, true);
@@ -749,7 +750,7 @@ contract HatsSignerGateTest is HSGTestSetup {
         // reoncile is called again and signerCount stays at 5
         // vm.expectRevert(MaxSignersReached.selector);
         hatsSignerGate.reconcileSignerCount();
-        assertEq(hatsSignerGate.signerCount(), 5);
+        assertEq(hatsSignerGate.validSignerCount(), 5);
 
         // // any eligible signer can now claim at will
         // mockIsWearerCall(addresses[6], signerHat, true);
@@ -770,7 +771,7 @@ contract HatsSignerGateTest is HSGTestSetup {
         // 3) reconcile is called, signerCount=x-3
         hatsSignerGate.reconcileSignerCount();
         console2.log("A");
-        assertEq(hatsSignerGate.signerCount(), 2);
+        assertEq(hatsSignerGate.validSignerCount(), 2);
 
         // 4) 3 more signers can be added with claimSigner()
         mockIsWearerCall(addresses[5], signerHat, true);
@@ -784,7 +785,7 @@ contract HatsSignerGateTest is HSGTestSetup {
         hatsSignerGate.claimSigner();
 
         console2.log("B");
-        assertEq(hatsSignerGate.signerCount(), 5);
+        assertEq(hatsSignerGate.validSignerCount(), 5);
         console2.log("C");
         assertEq(safe.getOwners().length, 5);
 
@@ -795,14 +796,14 @@ contract HatsSignerGateTest is HSGTestSetup {
 
         // but we still only have 5 owners and 5 signers
         console2.log("D");
-        assertEq(hatsSignerGate.signerCount(), 5);
+        assertEq(hatsSignerGate.validSignerCount(), 5);
 
         console2.log("E");
         assertEq(safe.getOwners().length, 5);
 
         console2.log("F");
         hatsSignerGate.reconcileSignerCount();
-        assertEq(hatsSignerGate.signerCount(), 5);
+        assertEq(hatsSignerGate.validSignerCount(), 5);
 
         // // 6) we now have x+3 signers
         // hatsSignerGate.reconcileSignerCount();
@@ -911,9 +912,7 @@ contract HatsSignerGateTest is HSGTestSetup {
 
         // reconcile is called, so signerCount is updated to 2
         hatsSignerGate.reconcileSignerCount();
-        console2.log("A");
-        assertEq(hatsSignerGate.signerCount(), 2);
-        console2.log("B");
+        assertEq(hatsSignerGate.validSignerCount(), 2);
         assertEq(safe.getThreshold(), 2);
 
         // the 3 owners regain their hats
@@ -953,33 +952,65 @@ contract HatsSignerGateTest is HSGTestSetup {
     }
 
     function testCannotClaimSignerIfNoInvalidSigners() public {
-        console2.log("A");
         assertEq(maxSigners, 5);
         addSigners(5);
         // one signer loses their hat
         mockIsWearerCall(addresses[4], signerHat, false);
-        console2.log("B");
-        assertEq(hatsSignerGate.signerCount(), 5);
+        assertEq(hatsSignerGate.validSignerCount(), 4);
 
         // reconcile is called, updating signer count to 4
         hatsSignerGate.reconcileSignerCount();
-        console2.log("C");
-        assertEq(hatsSignerGate.signerCount(), 4);
+        assertEq(hatsSignerGate.validSignerCount(), 4);
 
         // bad signer regains their hat
         mockIsWearerCall(addresses[4], signerHat, true);
-        // signer count is still 4 because reoncile hasn't been called again
-        console2.log("D");
-        assertEq(hatsSignerGate.signerCount(), 4);
+        // signer count returns to 5
+        assertEq(hatsSignerGate.validSignerCount(), 5);
 
-        // new valid signer tries to claim, but can't because
+        // new valid signer tries to claim, but can't because we're already at max signers
         mockIsWearerCall(addresses[5], signerHat, true);
         vm.prank(addresses[5]);
-        vm.expectRevert(NoInvalidSignersToReplace.selector);
+        vm.expectRevert(MaxSignersReached.selector);
         hatsSignerGate.claimSigner();
     }
 
-    function testSignersCannotChangeModules() public {
-        //
+    function testRemoveSignerCorrectlyUpdates() public {
+        assertEq(hatsSignerGate.targetThreshold(), 2, "target threshold");
+        assertEq(maxSigners, 5, "max signers");
+        // start with 5 valid signers
+        addSigners(5);
+
+        // the last two lose their hats
+        mockIsWearerCall(addresses[3], signerHat, false);
+        mockIsWearerCall(addresses[4], signerHat, false);
+
+        // the 4th regains its hat
+        mockIsWearerCall(addresses[3], signerHat, true);
+
+        // remove the 5th signer
+        hatsSignerGate.removeSigner(addresses[4]);
+
+        // signer count should be 4 and threshold at target
+        assertEq(hatsSignerGate.validSignerCount(), 4, "valid signer count");
+        assertEq(safe.getThreshold(), hatsSignerGate.targetThreshold(), "ending threshold");
     }
+
+    function testCanClaimToReplaceInvalidSignerAtMaxSigner() public {
+        assertEq(maxSigners, 5, "max signers");
+        // start with 5 valid signers (the max)
+        addSigners(5);
+
+        // the last one loses their hat
+        mockIsWearerCall(addresses[4], signerHat, false);
+
+        // a new signer valid tries to claim, and can
+        mockIsWearerCall(addresses[5], signerHat, true);
+        vm.prank(addresses[5]);
+        hatsSignerGate.claimSigner();
+        assertEq(hatsSignerGate.validSignerCount(), 5, "valid signer count");
+    }
+
+    // function testSignersCannotChangeModules() public {
+    //     //
+    // }
 }

--- a/test/HatsSignerGate.t.sol
+++ b/test/HatsSignerGate.t.sol
@@ -1117,7 +1117,127 @@ contract HatsSignerGateTest is HSGTestSetup {
         assertEq(safe.nonce(), 0, "post nonce hasn't changed");
     }
 
-    // function testSignersCannotChangeModules() public {
-    //     //
-    // }
+    function testSignersCannotReenterCheckTransactionToAddOwners() public {
+        address newOwner = makeAddr("newOwner");
+        bytes memory addOwnerAction;
+        bytes memory sigs;
+        bytes memory checkTxAction;
+        bytes memory multisend;
+        // start with 3 valid signers
+        addSigners(3);
+        // attacker is the first of these signers
+        address attacker = addresses[0];
+        assertEq(safe.getThreshold(), 2, "initial threshold");
+        assertEq(safe.getOwners().length, 3, "initial owner count");
+
+        /* attacker crafts a multisend tx to submit to the safe, with the following actions:
+            1) add a new owner 
+                — when `HSG.checkTransaction` is called, the hash of the original owner array will be stored
+            2) directly call `HSG.checkTransaction` 
+                — this will cause the hash of the new owner array (with the new owner from #1) to be stored
+                — when `HSG.checkAfterExecution` is called, the owner array check will pass even though 
+        */
+
+        // 1) craft the addOwner action
+        // mock the new owner as a valid signer
+        mockIsWearerCall(newOwner, signerHat, true);
+        { // use scope to avoid stack too deep error
+            // compile the action
+            addOwnerAction = abi.encodeWithSignature("addOwnerWithThreshold(address,uint256)", newOwner, 2);
+
+            // 2) craft the direct checkTransaction action
+            // first craft a dummy/empty tx to pass to checkTransaction
+            bytes32 dummyTxHash = safe.getTransactionHash(
+                attacker, // send 0 eth to the attacker
+                0,
+                hex"00",
+                Enum.Operation.Call,
+                // not using the refunder
+                0,
+                0,
+                0,
+                address(0),
+                address(0),
+                safe.nonce()
+            );
+
+            // then have it signed by the attacker and a collaborator
+            sigs = createNSigsForTx(dummyTxHash, 2);
+
+            checkTxAction = abi.encodeWithSelector(
+                hatsSignerGate.checkTransaction.selector,
+                // checkTransaction params
+                attacker,
+                0,
+                hex"00",
+                Enum.Operation.Call,
+                0,
+                0,
+                0,
+                address(0),
+                payable(address(0)),
+                sigs,
+                attacker // msgSender
+            );
+
+            // now bundle the two actions into a multisend tx
+            bytes memory packedCalls = abi.encodePacked(
+                // 1) add owner
+                uint8(0), // 0 for call; 1 for delegatecall
+                safe, // to
+                uint256(0), // value
+                uint256(addOwnerAction.length), // data length
+                bytes(addOwnerAction), // data
+                // 2) direct call to checkTransaction
+                uint8(0), // 0 for call; 1 for delegatecall
+                hatsSignerGate, // to
+                uint256(0), // value
+                uint256(checkTxAction.length), // data length
+                bytes(checkTxAction) // data
+            );
+            multisend = abi.encodeWithSignature("multiSend(bytes)", packedCalls);
+        }
+
+        // now get the safe tx hash and have attacker sign it with a collaborator
+        bytes32 safeTxHash = safe.getTransactionHash(
+            gnosisMultisendLibrary, // to
+            0, // value
+            multisend, // data
+            Enum.Operation.DelegateCall, // operation
+            0, // safeTxGas
+            0, // baseGas
+            0, // gasPrice
+            address(0), // gasToken
+            address(0), // refundReceiver
+            safe.nonce() // nonce
+        );
+        sigs = createNSigsForTx(safeTxHash, 2);
+
+        // now submit the tx to the safe
+        vm.prank(attacker);
+        /* 
+        Expect revert because of re-entry into checkTransaction
+        While hatsSignerGate will throw the NoReentryAllowed error, 
+        since the error occurs within the context of the safe transaction, 
+        the safe will catch the error and re-throw with its own error, 
+        ie `GS013` ("Safe transaction failed when gasPrice and safeTxGas were 0")
+        */
+        vm.expectRevert(bytes("GS013"));
+        safe.execTransaction(
+            gnosisMultisendLibrary,
+            0,
+            multisend,
+            Enum.Operation.DelegateCall,
+            // not using the refunder
+            0,
+            0,
+            0,
+            address(0),
+            payable(address(0)),
+            sigs
+        );
+
+        // no new owners have been added, despite the attacker's best efforts
+        assertEq(safe.getOwners().length, 3, "post owner count");
+    }
 }

--- a/test/HatsSignerGateFactory.t.sol
+++ b/test/HatsSignerGateFactory.t.sol
@@ -187,19 +187,6 @@ contract HatsSignerGateFactoryTest is HSGFactoryTestSetup {
 
         // add a module
         bytes memory addModuleData = abi.encodeWithSignature("enableModule(address)", address(0xf00baa)); // some devs are from Boston
-        bytes32 txHash = safe.getTransactionHash(
-            address(safe),
-            0,
-            addModuleData,
-            Enum.Operation.Call,
-            // not using the refunder
-            0,
-            0,
-            0,
-            address(0),
-            payable(address(0)),
-            safe.nonce()
-        );
         executeSafeTxFrom(address(this), addModuleData, safe);
 
         // attempt to deploy HSG, should revert
@@ -221,19 +208,6 @@ contract HatsSignerGateFactoryTest is HSGFactoryTestSetup {
 
         // add a module
         bytes memory addModuleData = abi.encodeWithSignature("enableModule(address)", address(0xf00baa)); // some devs are from Boston
-        bytes32 txHash = safe.getTransactionHash(
-            address(safe),
-            0,
-            addModuleData,
-            Enum.Operation.Call,
-            // not using the refunder
-            0,
-            0,
-            0,
-            address(0),
-            payable(address(0)),
-            safe.nonce()
-        );
         executeSafeTxFrom(address(this), addModuleData, safe);
 
         // attempt to deploy HSG, should revert
@@ -241,5 +215,167 @@ contract HatsSignerGateFactoryTest is HSGFactoryTestSetup {
         factory.deployMultiHatsSignerGate(
             ownerHat, signerHats, address(safe), minThreshold, targetThreshold, maxSigners
         );
+    }
+
+    function testCanAttachHSGToSafeReturnsFalseWithModule() public {
+        ownerHat = 1;
+        signerHat = 2;
+        minThreshold = 2;
+        targetThreshold = 2;
+        maxSigners = 5;
+
+        // deploy a safe
+        initSafeOwners[0] = address(this);
+        safe = deploySafe(initSafeOwners, 1);
+
+        // deploy HSG
+        address hsg =
+            factory.deployHatsSignerGate(ownerHat, signerHat, address(safe), minThreshold, targetThreshold, maxSigners);
+
+        // enable a module
+        bytes memory enableModuleData = abi.encodeWithSignature("enableModule(address)", address(0xf00baa)); // some devs are from Boston
+        executeSafeTxFrom(address(this), enableModuleData, safe);
+
+        // canAttachHSGToSafe should return false
+        assertFalse(factory.canAttachHSGToSafe(HatsSignerGate(hsg)));
+    }
+
+    function testCanAttachHSGToSafeReturnsFalseWithUnsafeSignerCounts() public {
+        ownerHat = 1;
+        signerHat = 2;
+        minThreshold = 1;
+        targetThreshold = 1;
+        maxSigners = 2;
+
+        // deploy a safe
+        initSafeOwners[0] = address(this);
+        mockIsWearerCall(address(this), signerHat, true);
+        safe = deploySafe(initSafeOwners, 1);
+
+        // deploy HSG
+        HatsSignerGate hsg = HatsSignerGate(
+            factory.deployHatsSignerGate(ownerHat, signerHat, address(safe), minThreshold, targetThreshold, maxSigners)
+        );
+
+        // add 2 owners and make them valid
+        bytes memory addOwnerData = abi.encodeWithSignature("addOwnerWithThreshold(address,uint256)", address(2), 1);
+        executeSafeTxFrom(address(this), addOwnerData, safe);
+        mockIsWearerCall(address(2), signerHat, true);
+
+        addOwnerData = abi.encodeWithSignature("addOwnerWithThreshold(address,uint256)", address(3), 1);
+        executeSafeTxFrom(address(this), addOwnerData, safe);
+        mockIsWearerCall(address(3), signerHat, true);
+
+        // canAttachHSGToSafe should return false
+        assertEq(hsg.validSignerCount(), 3, "valid signer count");
+        assertEq(hsg.maxSigners(), 2, "max signers");
+        assertFalse(
+            factory.canAttachHSGToSafe(HatsSignerGate(hsg)), "should return false with validSignerCount > maxSigners"
+        );
+    }
+
+    function testCanAttachHSGToSafeReturnsTrue() public {
+        ownerHat = 1;
+        signerHat = 2;
+        minThreshold = 2;
+        targetThreshold = 2;
+        maxSigners = 5;
+
+        // deploy a safe
+        initSafeOwners[0] = address(this);
+        mockIsWearerCall(address(this), signerHat, true);
+        safe = deploySafe(initSafeOwners, 1);
+
+        // deploy HSG
+        address hsg =
+            factory.deployHatsSignerGate(ownerHat, signerHat, address(safe), minThreshold, targetThreshold, maxSigners);
+
+        // canAttachHSGToSafe should return true
+        assertTrue(factory.canAttachHSGToSafe(HatsSignerGate(hsg)));
+    }
+
+    function testCanAttachMHSGToSafeReturnsFalseWithModule() public {
+        ownerHat = 1;
+        minThreshold = 2;
+        targetThreshold = 2;
+        maxSigners = 5;
+        // create signerHats array
+        uint256[] memory signerHats = new uint256[](1);
+        signerHats[0] = 2;
+
+        // deploy a safe
+        initSafeOwners[0] = address(this);
+        safe = deploySafe(initSafeOwners, 1);
+
+        // deploy MHSG
+        address mhsg = factory.deployMultiHatsSignerGate(
+            ownerHat, signerHats, address(safe), minThreshold, targetThreshold, maxSigners
+        );
+
+        // enable a module
+        bytes memory enableModuleData = abi.encodeWithSignature("enableModule(address)", address(0xf00baa)); // some devs are from Boston
+        executeSafeTxFrom(address(this), enableModuleData, safe);
+
+        // canAttachHSGToSafe should return false
+        assertFalse(factory.canAttachMHSGToSafe(MultiHatsSignerGate(mhsg)));
+    }
+
+    function testCanAttachMHSGToSafeReturnsFalseWithUnsafeSignerCounts() public {
+        ownerHat = 1;
+        minThreshold = 1;
+        targetThreshold = 1;
+        maxSigners = 2;
+        // create signerHats array
+        uint256[] memory signerHats = new uint256[](1);
+        signerHats[0] = 2;
+
+        // deploy a safe
+        initSafeOwners[0] = address(this);
+        mockIsWearerCall(address(this), signerHat, true);
+        safe = deploySafe(initSafeOwners, 1);
+
+        // deploy MHSG
+        MultiHatsSignerGate mhsg = MultiHatsSignerGate(
+            factory.deployMultiHatsSignerGate(
+                ownerHat, signerHats, address(safe), minThreshold, targetThreshold, maxSigners
+            )
+        );
+
+        // add 2 owners and make them valid
+        bytes memory addOwnerData = abi.encodeWithSignature("addOwnerWithThreshold(address,uint256)", address(2), 1);
+        executeSafeTxFrom(address(this), addOwnerData, safe);
+        mockIsWearerCall(address(2), signerHat, true);
+
+        addOwnerData = abi.encodeWithSignature("addOwnerWithThreshold(address,uint256)", address(3), 1);
+        executeSafeTxFrom(address(this), addOwnerData, safe);
+        mockIsWearerCall(address(3), signerHat, true);
+
+        // canAttachHSGToSafe should return false
+        assertEq(mhsg.validSignerCount(), 3, "valid signer count");
+        assertEq(mhsg.maxSigners(), 2, "max signers");
+        assertFalse(factory.canAttachMHSGToSafe(mhsg), "should return false with validSignerCount > maxSigners");
+    }
+
+    function testCanAttachMHSGToSafeReturnsTrue() public {
+        ownerHat = 1;
+        minThreshold = 2;
+        targetThreshold = 2;
+        maxSigners = 5;
+        // create signerHats array
+        uint256[] memory signerHats = new uint256[](1);
+        signerHats[0] = 2;
+
+        // deploy a safe
+        initSafeOwners[0] = address(this);
+        mockIsWearerCall(address(this), signerHat, true);
+        safe = deploySafe(initSafeOwners, 1);
+
+        // deploy MHSG
+        address mhsg = factory.deployMultiHatsSignerGate(
+            ownerHat, signerHats, address(safe), minThreshold, targetThreshold, maxSigners
+        );
+
+        // canAttachHSGToSafe should return true
+        assertTrue(factory.canAttachMHSGToSafe(MultiHatsSignerGate(mhsg)));
     }
 }

--- a/test/MHSGTestSetup.t.sol
+++ b/test/MHSGTestSetup.t.sol
@@ -39,6 +39,7 @@ contract MHSGTestSetup is HSGTestSetup {
         );
 
         (multiHatsSignerGate, safe) = deployMHSGAndSafe(ownerHat, signerHats, minThreshold, targetThreshold, maxSigners);
+        mockIsWearerCall(address(multiHatsSignerGate), signerHat, false);
     }
 
     function addSigners_Multi(uint256 count) internal {

--- a/test/MultiHatsSignerGate.t.sol
+++ b/test/MultiHatsSignerGate.t.sol
@@ -7,7 +7,7 @@ contract MultiHatsSignerGateTest is MHSGTestSetup {
     function test_Multi_AddSingleSigner() public {
         addSigners_Multi(1);
 
-        assertEq(multiHatsSignerGate.signerCount(), 1);
+        assertEq(multiHatsSignerGate.validSignerCount(), 1);
         assertEq(safe.getOwners()[0], addresses[0]);
         assertEq(safe.getThreshold(), 1);
     }
@@ -15,7 +15,7 @@ contract MultiHatsSignerGateTest is MHSGTestSetup {
     function test_Multi_AddTwoSigners_DifferentHats() public {
         addSigners_Multi(2);
 
-        assertEq(multiHatsSignerGate.signerCount(), 2);
+        assertEq(multiHatsSignerGate.validSignerCount(), 2);
         assertEq(safe.getOwners()[0], addresses[1]);
         assertEq(safe.getOwners()[1], addresses[0]);
         assertEq(safe.getThreshold(), 2);
@@ -40,7 +40,7 @@ contract MultiHatsSignerGateTest is MHSGTestSetup {
 
         assertEq(safe.getOwners().length, 1);
         assertEq(safe.getOwners()[0], address(multiHatsSignerGate));
-        assertEq(multiHatsSignerGate.signerCount(), 0);
+        assertEq(multiHatsSignerGate.validSignerCount(), 0);
         assertEq(safe.getThreshold(), 1);
     }
 
@@ -55,7 +55,7 @@ contract MultiHatsSignerGateTest is MHSGTestSetup {
 
         assertEq(safe.getOwners().length, 1);
         assertEq(safe.getOwners()[0], addresses[0]);
-        assertEq(multiHatsSignerGate.signerCount(), 1);
+        assertEq(multiHatsSignerGate.validSignerCount(), 1);
 
         assertEq(safe.getThreshold(), 1);
     }


### PR DESCRIPTION
Addresses the following findings by replacing the `signerCount` state variable with a dynamic `validSignerCount()` function.

https://github.com/sherlock-audit/2023-02-hats-judging/issues/111
https://github.com/sherlock-audit/2023-02-hats-judging/issues/79
https://github.com/sherlock-audit/2023-02-hats-judging/issues/27