### PR TITLE
Fix for sherlock issue 50

### DIFF
--- a/src/HSGLib.sol
+++ b/src/HSGLib.sol
@@ -76,3 +76,7 @@ error SignersCannotChangeOwners();
 /// @notice Emmitted when a call to `checkTransaction` or `checkAfterExecution` is not made from the `safe`
 /// @dev Together with `guardEntries`, protects against arbitrary reentrancy attacks by the signers
 error NotCalledFromSafe();
+
+/// @notice Emmitted when attempting to reenter `checkTransaction`
+/// @dev The Safe will catch this error and re-throw with its own error message (`GS013`)
+error NoReentryAllowed();

--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0
 pragma solidity >=0.8.13;
 
-import { Test, console2 } from "forge-std/Test.sol"; // remove after testing
+// import { Test, console2 } from "forge-std/Test.sol"; // remove after testing
 import { HatsSignerGateBase, IGnosisSafe, Enum } from "./HatsSignerGateBase.sol";
 import "./HSGLib.sol";
 
@@ -72,8 +72,6 @@ contract HatsSignerGate is HatsSignerGateBase {
     /// @param _account The address to check
     /// @return valid Whether `_account` is a valid signer
     function isValidSigner(address _account) public view override returns (bool valid) {
-        // console2.log("ivs 1");
         valid = HATS.isWearerOfHat(_account, signersHatId);
-        // console2.log("ivs 2");
     }
 }

--- a/src/HatsSignerGateBase.sol
+++ b/src/HatsSignerGateBase.sol
@@ -425,14 +425,12 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
         address // msgSender
     ) external override {
         if (msg.sender != address(safe)) revert NotCalledFromSafe();
-
         // get the safe owners
         address[] memory owners = safe.getOwners();
         {
             // scope to avoid stack too deep errors
             uint256 safeOwnerCount = owners.length;
             // uint256 validSignerCount = _countValidSigners(safe.getOwners());
-
             // ensure that safe threshold is correct
             reconcileSignerCount();
 
@@ -440,7 +438,6 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
                 revert BelowMinThreshold(minThreshold, safeOwnerCount);
             }
         }
-
         // get the tx hash; view function
         bytes32 txHash = safe.getTransactionHash(
             // Transaction info
@@ -472,6 +469,8 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
         unchecked {
             ++_guardEntries;
         }
+        // revert if re-entry is detected
+        if (_guardEntries > 1) revert NoReentryAllowed();
     }
 
     /**
@@ -517,7 +516,7 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
         else if (modulesWith1[0] != address(this)) {
             revert SignersCannotChangeModules();
         }
-        // leave checked to catch underflows triggered by re-erntry attempts
+        // leave checked to catch underflows triggered by re-entry attempts
         --_guardEntries;
     }
 

--- a/src/HatsSignerGateBase.sol
+++ b/src/HatsSignerGateBase.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0
 pragma solidity >=0.8.13;
 
-import { Test, console2 } from "forge-std/Test.sol"; // remove after testing
+// import { Test, console2 } from "forge-std/Test.sol"; // remove after testing
 import "./HSGLib.sol";
 import { HatsOwnedInitializable } from "hats-auth/HatsOwnedInitializable.sol";
 import { BaseGuard } from "zodiac/guard/BaseGuard.sol";
@@ -22,9 +22,6 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
 
     /// @notice The maximum number of signers allowed for the `safe`
     uint256 public maxSigners;
-
-    // /// @notice The current number of signers on the `safe`
-    // uint256 public signerCount;
 
     /// @notice The version of HatsSignerGate used in this contract
     string public version;
@@ -125,7 +122,6 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
     /// @param _signerCount The number of valid signers on the `safe`; should be calculated from `validSignerCount()`
     function _setSafeThreshold(uint256 _threshold, uint256 _signerCount) internal {
         uint256 newThreshold = _threshold;
-        // uint256 signerCount = validSignerCount();
 
         // ensure that txs can't execute if fewer signers than target threshold
         if (_signerCount <= _threshold) {
@@ -200,6 +196,8 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
         }
     }
 
+    /// @notice Tallies the number of existing `safe` owners that wear a signer hat
+    /// @return signerCount The number of valid signers on the `safe`
     function validSignerCount() public view returns (uint256 signerCount) {
         signerCount = _countValidSigners(safe.getOwners());
     }

--- a/src/HatsSignerGateBase.sol
+++ b/src/HatsSignerGateBase.sol
@@ -458,11 +458,11 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
             // We subtract 1 since nonce was just incremented in the parent function call
             safe.nonce() - 1 // view function
         );
-
-        uint256 validSigCount = countValidSignatures(txHash, signatures, signatures.length / 65);
+        uint256 threshold = safe.getThreshold();
+        uint256 validSigCount = countValidSignatures(txHash, signatures, threshold);
 
         // revert if there aren't enough valid signatures
-        if (validSigCount < safe.getThreshold() || validSigCount < minThreshold) {
+        if (validSigCount < threshold || validSigCount < minThreshold) {
             revert InvalidSigners();
         }
 

--- a/src/HatsSignerGateBase.sol
+++ b/src/HatsSignerGateBase.sol
@@ -295,7 +295,7 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
         address ownerToCheck;
         bytes memory data;
 
-        for (uint256 i; i < _ownerCount - 1;) {
+        for (uint256 i; i < _ownerCount;) {
             ownerToCheck = _owners[i];
 
             if (!isValidSigner(ownerToCheck)) {

--- a/src/HatsSignerGateFactory.sol
+++ b/src/HatsSignerGateFactory.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0
 pragma solidity >=0.8.13;
 
-import { console2 } from "forge-std/Test.sol"; // remove after testing
+// import { console2 } from "forge-std/Test.sol"; // remove after testing
 import "./HatsSignerGate.sol";
 import "./MultiHatsSignerGate.sol";
 import "@gnosis.pm/safe-contracts/contracts/GnosisSafe.sol";

--- a/test/HSGFactoryTestSetup.t.sol
+++ b/test/HSGFactoryTestSetup.t.sol
@@ -124,4 +124,9 @@ contract HSGFactoryTestSetup is Test {
             abi.encode(from, bytes32(0), bytes1(0x01))
         );
     }
+
+    function mockIsWearerCall(address wearer, uint256 hat, bool result) public {
+        bytes memory data = abi.encodeWithSignature("isWearerOfHat(address,uint256)", wearer, hat);
+        vm.mockCall(HATS, data, abi.encode(result));
+    }
 }

--- a/test/HSGTestSetup.t.sol
+++ b/test/HSGTestSetup.t.sol
@@ -60,11 +60,6 @@ contract HSGTestSetup is HSGFactoryTestSetup, SignatureDecoder {
         }
     }
 
-    function mockIsWearerCall(address wearer, uint256 hat, bool result) public {
-        bytes memory data = abi.encodeWithSignature("isWearerOfHat(address,uint256)", wearer, hat);
-        vm.mockCall(HATS, data, abi.encode(result));
-    }
-
     function getEthTransferSafeTxHash(address to, uint256 value, GnosisSafe _safe)
         public
         view

--- a/test/HatsSignerGate.t.sol
+++ b/test/HatsSignerGate.t.sol
@@ -1141,7 +1141,8 @@ contract HatsSignerGateTest is HSGTestSetup {
         // 1) craft the addOwner action
         // mock the new owner as a valid signer
         mockIsWearerCall(newOwner, signerHat, true);
-        { // use scope to avoid stack too deep error
+        {
+            // use scope to avoid stack too deep error
             // compile the action
             addOwnerAction = abi.encodeWithSignature("addOwnerWithThreshold(address,uint256)", newOwner, 2);
 

--- a/test/HatsSignerGate.t.sol
+++ b/test/HatsSignerGate.t.sol
@@ -826,6 +826,24 @@ contract HatsSignerGateTest is HSGTestSetup {
         hatsSignerGate.claimSigner();
     }
 
+    function testValidSignersCanClaimAfterLastMaxSignerLosesHat() public {
+        // max signers is 5
+        // 5 signers claim
+        addSigners(5);
+
+        address[] memory owners = safe.getOwners();
+
+        // a signer misbehaves and loses the hat
+        mockIsWearerCall(owners[4], signerHat, false);
+
+        // validSignerCount is now 4
+        assertEq(hatsSignerGate.validSignerCount(), 4);
+
+        mockIsWearerCall(addresses[5], signerHat, true);
+        vm.prank(addresses[5]);
+        hatsSignerGate.claimSigner();
+    }
+
     function testSignersCannotAddNewModules() public {
         (address[] memory modules,) = safe.getModulesPaginated(SENTINELS, 5);
         console2.log(modules.length);

--- a/test/HatsSignerGate.t.sol
+++ b/test/HatsSignerGate.t.sol
@@ -1117,7 +1117,127 @@ contract HatsSignerGateTest is HSGTestSetup {
         assertEq(safe.nonce(), 0, "post nonce hasn't changed");
     }
 
-    // function testSignersCannotChangeModules() public {
-    //     //
-    // }
+    function testSignersCannotReenterCheckTransactionToAddOwners() public {
+        address newOwner = makeAddr("newOwner");
+        bytes memory addOwnerAction;
+        bytes memory sigs;
+        bytes memory checkTxAction;
+        bytes memory multisend;
+        // start with 3 valid signers
+        addSigners(3);
+        // attacker is the first of these signers
+        address attacker = addresses[0];
+        assertEq(safe.getThreshold(), 2, "initial threshold");
+        assertEq(safe.getOwners().length, 3, "initial owner count");
+
+        /* attacker crafts a multisend tx to submit to the safe, with the following actions:
+            1) add a new owner 
+                — when `HSG.checkTransaction` is called, the hash of the original owner array will be stored
+            2) directly call `HSG.checkTransaction` 
+                — this will cause the hash of the new owner array (with the new owner from #1) to be stored
+                — when `HSG.checkAfterExecution` is called, the owner array check will pass even though 
+        */
+
+        // 1) craft the addOwner action
+        // mock the new owner as a valid signer
+        mockIsWearerCall(newOwner, signerHat, true);
+        { // use scope to avoid stack too deep error
+            // compile the action
+            addOwnerAction = abi.encodeWithSignature("addOwnerWithThreshold(address,uint256)", newOwner, 2);
+
+            // 2) craft the direct checkTransaction action
+            // first craft a dummy/empty tx to pass to checkTransaction
+            bytes32 dummyTxHash = safe.getTransactionHash(
+                attacker, // send 0 eth to the attacker
+                0,
+                hex"00",
+                Enum.Operation.Call,
+                // not using the refunder
+                0,
+                0,
+                0,
+                address(0),
+                address(0),
+                safe.nonce()
+            );
+
+            // then have it signed by the attacker and a collaborator
+            sigs = createNSigsForTx(dummyTxHash, 2);
+
+            checkTxAction = abi.encodeWithSelector(
+                hatsSignerGate.checkTransaction.selector,
+                // checkTransaction params
+                attacker,
+                0,
+                hex"00",
+                Enum.Operation.Call,
+                0,
+                0,
+                0,
+                address(0),
+                payable(address(0)),
+                sigs,
+                attacker // msgSender
+            );
+
+            // now bundle the two actions into a multisend tx
+            bytes memory packedCalls = abi.encodePacked(
+                // 1) add owner
+                uint8(0), // 0 for call; 1 for delegatecall
+                safe, // to
+                uint256(0), // value
+                uint256(addOwnerAction.length), // data length
+                bytes(addOwnerAction), // data
+                // 2) direct call to checkTransaction
+                uint8(0), // 0 for call; 1 for delegatecall
+                hatsSignerGate, // to
+                uint256(0), // value
+                uint256(checkTxAction.length), // data length
+                bytes(checkTxAction) // data
+            );
+            multisend = abi.encodeWithSignature("multiSend(bytes)", packedCalls);
+        }
+
+        // now get the safe tx hash and have attacker sign it with a collaborator
+        bytes32 safeTxHash = safe.getTransactionHash(
+            gnosisMultisendLibrary, // to
+            0, // value
+            multisend, // data
+            Enum.Operation.DelegateCall, // operation
+            0, // safeTxGas
+            0, // baseGas
+            0, // gasPrice
+            address(0), // gasToken
+            address(0), // refundReceiver
+            safe.nonce() // nonce
+        );
+        sigs = createNSigsForTx(safeTxHash, 2);
+
+        // now submit the tx to the safe
+        vm.prank(attacker);
+        /* 
+        Expect revert because of re-entry into checkTransaction
+        While hatsSignerGate will throw the NoReentryAllowed error, 
+        since the error occurs within the context of the safe transaction, 
+        the safe will catch the error and re-throw with its own error, 
+        ie `GS013` ("Safe transaction failed when gasPrice and safeTxGas were 0")
+        */
+        vm.expectRevert(bytes("GS013"));
+        safe.execTransaction(
+            gnosisMultisendLibrary,
+            0,
+            multisend,
+            Enum.Operation.DelegateCall,
+            // not using the refunder
+            0,
+            0,
+            0,
+            address(0),
+            payable(address(0)),
+            sigs
+        );
+
+        // no new owners have been added, despite the attacker's best efforts
+        assertEq(safe.getOwners().length, 3, "post owner count");
+    }
 }

--- a/test/HatsSignerGateFactory.t.sol
+++ b/test/HatsSignerGateFactory.t.sol
@@ -187,19 +187,6 @@ contract HatsSignerGateFactoryTest is HSGFactoryTestSetup {
 
         // add a module
         bytes memory addModuleData = abi.encodeWithSignature("enableModule(address)", address(0xf00baa)); // some devs are from Boston
-        bytes32 txHash = safe.getTransactionHash(
-            address(safe),
-            0,
-            addModuleData,
-            Enum.Operation.Call,
-            // not using the refunder
-            0,
-            0,
-            0,
-            address(0),
-            payable(address(0)),
-            safe.nonce()
-        );
         executeSafeTxFrom(address(this), addModuleData, safe);
 
         // attempt to deploy HSG, should revert
@@ -221,19 +208,6 @@ contract HatsSignerGateFactoryTest is HSGFactoryTestSetup {
 
         // add a module
         bytes memory addModuleData = abi.encodeWithSignature("enableModule(address)", address(0xf00baa)); // some devs are from Boston
-        bytes32 txHash = safe.getTransactionHash(
-            address(safe),
-            0,
-            addModuleData,
-            Enum.Operation.Call,
-            // not using the refunder
-            0,
-            0,
-            0,
-            address(0),
-            payable(address(0)),
-            safe.nonce()
-        );
         executeSafeTxFrom(address(this), addModuleData, safe);
 
         // attempt to deploy HSG, should revert
@@ -241,5 +215,167 @@ contract HatsSignerGateFactoryTest is HSGFactoryTestSetup {
         factory.deployMultiHatsSignerGate(
             ownerHat, signerHats, address(safe), minThreshold, targetThreshold, maxSigners
         );
+    }
+
+    function testCanAttachHSGToSafeReturnsFalseWithModule() public {
+        ownerHat = 1;
+        signerHat = 2;
+        minThreshold = 2;
+        targetThreshold = 2;
+        maxSigners = 5;
+
+        // deploy a safe
+        initSafeOwners[0] = address(this);
+        safe = deploySafe(initSafeOwners, 1);
+
+        // deploy HSG
+        address hsg =
+            factory.deployHatsSignerGate(ownerHat, signerHat, address(safe), minThreshold, targetThreshold, maxSigners);
+
+        // enable a module
+        bytes memory enableModuleData = abi.encodeWithSignature("enableModule(address)", address(0xf00baa)); // some devs are from Boston
+        executeSafeTxFrom(address(this), enableModuleData, safe);
+
+        // canAttachHSGToSafe should return false
+        assertFalse(factory.canAttachHSGToSafe(HatsSignerGate(hsg)));
+    }
+
+    function testCanAttachHSGToSafeReturnsFalseWithUnsafeSignerCounts() public {
+        ownerHat = 1;
+        signerHat = 2;
+        minThreshold = 1;
+        targetThreshold = 1;
+        maxSigners = 2;
+
+        // deploy a safe
+        initSafeOwners[0] = address(this);
+        mockIsWearerCall(address(this), signerHat, true);
+        safe = deploySafe(initSafeOwners, 1);
+
+        // deploy HSG
+        HatsSignerGate hsg = HatsSignerGate(
+            factory.deployHatsSignerGate(ownerHat, signerHat, address(safe), minThreshold, targetThreshold, maxSigners)
+        );
+
+        // add 2 owners and make them valid
+        bytes memory addOwnerData = abi.encodeWithSignature("addOwnerWithThreshold(address,uint256)", address(2), 1);
+        executeSafeTxFrom(address(this), addOwnerData, safe);
+        mockIsWearerCall(address(2), signerHat, true);
+
+        addOwnerData = abi.encodeWithSignature("addOwnerWithThreshold(address,uint256)", address(3), 1);
+        executeSafeTxFrom(address(this), addOwnerData, safe);
+        mockIsWearerCall(address(3), signerHat, true);
+
+        // canAttachHSGToSafe should return false
+        assertEq(hsg.validSignerCount(), 3, "valid signer count");
+        assertEq(hsg.maxSigners(), 2, "max signers");
+        assertFalse(
+            factory.canAttachHSGToSafe(HatsSignerGate(hsg)), "should return false with validSignerCount > maxSigners"
+        );
+    }
+
+    function testCanAttachHSGToSafeReturnsTrue() public {
+        ownerHat = 1;
+        signerHat = 2;
+        minThreshold = 2;
+        targetThreshold = 2;
+        maxSigners = 5;
+
+        // deploy a safe
+        initSafeOwners[0] = address(this);
+        mockIsWearerCall(address(this), signerHat, true);
+        safe = deploySafe(initSafeOwners, 1);
+
+        // deploy HSG
+        address hsg =
+            factory.deployHatsSignerGate(ownerHat, signerHat, address(safe), minThreshold, targetThreshold, maxSigners);
+
+        // canAttachHSGToSafe should return true
+        assertTrue(factory.canAttachHSGToSafe(HatsSignerGate(hsg)));
+    }
+
+    function testCanAttachMHSGToSafeReturnsFalseWithModule() public {
+        ownerHat = 1;
+        minThreshold = 2;
+        targetThreshold = 2;
+        maxSigners = 5;
+        // create signerHats array
+        uint256[] memory signerHats = new uint256[](1);
+        signerHats[0] = 2;
+
+        // deploy a safe
+        initSafeOwners[0] = address(this);
+        safe = deploySafe(initSafeOwners, 1);
+
+        // deploy MHSG
+        address mhsg = factory.deployMultiHatsSignerGate(
+            ownerHat, signerHats, address(safe), minThreshold, targetThreshold, maxSigners
+        );
+
+        // enable a module
+        bytes memory enableModuleData = abi.encodeWithSignature("enableModule(address)", address(0xf00baa)); // some devs are from Boston
+        executeSafeTxFrom(address(this), enableModuleData, safe);
+
+        // canAttachHSGToSafe should return false
+        assertFalse(factory.canAttachMHSGToSafe(MultiHatsSignerGate(mhsg)));
+    }
+
+    function testCanAttachMHSGToSafeReturnsFalseWithUnsafeSignerCounts() public {
+        ownerHat = 1;
+        minThreshold = 1;
+        targetThreshold = 1;
+        maxSigners = 2;
+        // create signerHats array
+        uint256[] memory signerHats = new uint256[](1);
+        signerHats[0] = 2;
+
+        // deploy a safe
+        initSafeOwners[0] = address(this);
+        mockIsWearerCall(address(this), signerHat, true);
+        safe = deploySafe(initSafeOwners, 1);
+
+        // deploy MHSG
+        MultiHatsSignerGate mhsg = MultiHatsSignerGate(
+            factory.deployMultiHatsSignerGate(
+                ownerHat, signerHats, address(safe), minThreshold, targetThreshold, maxSigners
+            )
+        );
+
+        // add 2 owners and make them valid
+        bytes memory addOwnerData = abi.encodeWithSignature("addOwnerWithThreshold(address,uint256)", address(2), 1);
+        executeSafeTxFrom(address(this), addOwnerData, safe);
+        mockIsWearerCall(address(2), signerHat, true);
+
+        addOwnerData = abi.encodeWithSignature("addOwnerWithThreshold(address,uint256)", address(3), 1);
+        executeSafeTxFrom(address(this), addOwnerData, safe);
+        mockIsWearerCall(address(3), signerHat, true);
+
+        // canAttachHSGToSafe should return false
+        assertEq(mhsg.validSignerCount(), 3, "valid signer count");
+        assertEq(mhsg.maxSigners(), 2, "max signers");
+        assertFalse(factory.canAttachMHSGToSafe(mhsg), "should return false with validSignerCount > maxSigners");
+    }
+
+    function testCanAttachMHSGToSafeReturnsTrue() public {
+        ownerHat = 1;
+        minThreshold = 2;
+        targetThreshold = 2;
+        maxSigners = 5;
+        // create signerHats array
+        uint256[] memory signerHats = new uint256[](1);
+        signerHats[0] = 2;
+
+        // deploy a safe
+        initSafeOwners[0] = address(this);
+        mockIsWearerCall(address(this), signerHat, true);
+        safe = deploySafe(initSafeOwners, 1);
+
+        // deploy MHSG
+        address mhsg = factory.deployMultiHatsSignerGate(
+            ownerHat, signerHats, address(safe), minThreshold, targetThreshold, maxSigners
+        );
+
+        // canAttachHSGToSafe should return true
+        assertTrue(factory.canAttachMHSGToSafe(MultiHatsSignerGate(mhsg)));
     }
 }


### PR DESCRIPTION
Address finding 50 — that an attacker could bypass HSG's signature validation — by ensuring that HSG checks the same signatures that the safe checks.

https://github.com/sherlock-audit/2023-02-hats-judging/issues/50