### PR TITLE
Fix for sherlock issue 93

### DIFF
--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0
 pragma solidity >=0.8.13;
 
-import { Test, console2 } from "forge-std/Test.sol"; // remove after testing
+// import { Test, console2 } from "forge-std/Test.sol"; // remove after testing
 import { HatsSignerGateBase, IGnosisSafe, Enum } from "./HatsSignerGateBase.sol";
 import "./HSGLib.sol";
 
@@ -72,8 +72,6 @@ contract HatsSignerGate is HatsSignerGateBase {
     /// @param _account The address to check
     /// @return valid Whether `_account` is a valid signer
     function isValidSigner(address _account) public view override returns (bool valid) {
-        // console2.log("ivs 1");
         valid = HATS.isWearerOfHat(_account, signersHatId);
-        // console2.log("ivs 2");
     }
 }

--- a/src/HatsSignerGateBase.sol
+++ b/src/HatsSignerGateBase.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0
 pragma solidity >=0.8.13;
 
-import { Test, console2 } from "forge-std/Test.sol"; // remove after testing
+// import { Test, console2 } from "forge-std/Test.sol"; // remove after testing
 import "./HSGLib.sol";
 import { HatsOwnedInitializable } from "hats-auth/HatsOwnedInitializable.sol";
 import { BaseGuard } from "zodiac/guard/BaseGuard.sol";
@@ -22,9 +22,6 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
 
     /// @notice The maximum number of signers allowed for the `safe`
     uint256 public maxSigners;
-
-    // /// @notice The current number of signers on the `safe`
-    // uint256 public signerCount;
 
     /// @notice The version of HatsSignerGate used in this contract
     string public version;
@@ -125,7 +122,6 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
     /// @param _signerCount The number of valid signers on the `safe`; should be calculated from `validSignerCount()`
     function _setSafeThreshold(uint256 _threshold, uint256 _signerCount) internal {
         uint256 newThreshold = _threshold;
-        // uint256 signerCount = validSignerCount();
 
         // ensure that txs can't execute if fewer signers than target threshold
         if (_signerCount <= _threshold) {
@@ -200,6 +196,8 @@ abstract contract HatsSignerGateBase is BaseGuard, SignatureDecoder, HatsOwnedIn
         }
     }
 
+    /// @notice Tallies the number of existing `safe` owners that wear a signer hat
+    /// @return signerCount The number of valid signers on the `safe`
     function validSignerCount() public view returns (uint256 signerCount) {
         signerCount = _countValidSigners(safe.getOwners());
     }

--- a/src/HatsSignerGateFactory.sol
+++ b/src/HatsSignerGateFactory.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0
 pragma solidity >=0.8.13;
 
-import { console2 } from "forge-std/Test.sol"; // remove after testing
+// import { console2 } from "forge-std/Test.sol"; // remove after testing
 import "./HatsSignerGate.sol";
 import "./MultiHatsSignerGate.sol";
 import "@gnosis.pm/safe-contracts/contracts/GnosisSafe.sol";

--- a/test/HSGFactoryTestSetup.t.sol
+++ b/test/HSGFactoryTestSetup.t.sol
@@ -124,4 +124,9 @@ contract HSGFactoryTestSetup is Test {
             abi.encode(from, bytes32(0), bytes1(0x01))
         );
     }
+
+    function mockIsWearerCall(address wearer, uint256 hat, bool result) public {
+        bytes memory data = abi.encodeWithSignature("isWearerOfHat(address,uint256)", wearer, hat);
+        vm.mockCall(HATS, data, abi.encode(result));
+    }
 }

--- a/test/HSGTestSetup.t.sol
+++ b/test/HSGTestSetup.t.sol
@@ -60,11 +60,6 @@ contract HSGTestSetup is HSGFactoryTestSetup, SignatureDecoder {
         }
     }
 
-    function mockIsWearerCall(address wearer, uint256 hat, bool result) public {
-        bytes memory data = abi.encodeWithSignature("isWearerOfHat(address,uint256)", wearer, hat);
-        vm.mockCall(HATS, data, abi.encode(result));
-    }
-
     function getEthTransferSafeTxHash(address to, uint256 value, GnosisSafe _safe)
         public
         view

--- a/test/HatsSignerGate.t.sol
+++ b/test/HatsSignerGate.t.sol
@@ -1141,7 +1141,8 @@ contract HatsSignerGateTest is HSGTestSetup {
         // 1) craft the addOwner action
         // mock the new owner as a valid signer
         mockIsWearerCall(newOwner, signerHat, true);
-        { // use scope to avoid stack too deep error
+        {
+            // use scope to avoid stack too deep error
             // compile the action
             addOwnerAction = abi.encodeWithSignature("addOwnerWithThreshold(address,uint256)", newOwner, 2);
 

--- a/test/HatsSignerGateFactory.t.sol
+++ b/test/HatsSignerGateFactory.t.sol
@@ -187,19 +187,6 @@ contract HatsSignerGateFactoryTest is HSGFactoryTestSetup {
 
         // add a module
         bytes memory addModuleData = abi.encodeWithSignature("enableModule(address)", address(0xf00baa)); // some devs are from Boston
-        bytes32 txHash = safe.getTransactionHash(
-            address(safe),
-            0,
-            addModuleData,
-            Enum.Operation.Call,
-            // not using the refunder
-            0,
-            0,
-            0,
-            address(0),
-            payable(address(0)),
-            safe.nonce()
-        );
         executeSafeTxFrom(address(this), addModuleData, safe);
 
         // attempt to deploy HSG, should revert
@@ -221,19 +208,6 @@ contract HatsSignerGateFactoryTest is HSGFactoryTestSetup {
 
         // add a module
         bytes memory addModuleData = abi.encodeWithSignature("enableModule(address)", address(0xf00baa)); // some devs are from Boston
-        bytes32 txHash = safe.getTransactionHash(
-            address(safe),
-            0,
-            addModuleData,
-            Enum.Operation.Call,
-            // not using the refunder
-            0,
-            0,
-            0,
-            address(0),
-            payable(address(0)),
-            safe.nonce()
-        );
         executeSafeTxFrom(address(this), addModuleData, safe);
 
         // attempt to deploy HSG, should revert
@@ -241,5 +215,167 @@ contract HatsSignerGateFactoryTest is HSGFactoryTestSetup {
         factory.deployMultiHatsSignerGate(
             ownerHat, signerHats, address(safe), minThreshold, targetThreshold, maxSigners
         );
+    }
+
+    function testCanAttachHSGToSafeReturnsFalseWithModule() public {
+        ownerHat = 1;
+        signerHat = 2;
+        minThreshold = 2;
+        targetThreshold = 2;
+        maxSigners = 5;
+
+        // deploy a safe
+        initSafeOwners[0] = address(this);
+        safe = deploySafe(initSafeOwners, 1);
+
+        // deploy HSG
+        address hsg =
+            factory.deployHatsSignerGate(ownerHat, signerHat, address(safe), minThreshold, targetThreshold, maxSigners);
+
+        // enable a module
+        bytes memory enableModuleData = abi.encodeWithSignature("enableModule(address)", address(0xf00baa)); // some devs are from Boston
+        executeSafeTxFrom(address(this), enableModuleData, safe);
+
+        // canAttachHSGToSafe should return false
+        assertFalse(factory.canAttachHSGToSafe(HatsSignerGate(hsg)));
+    }
+
+    function testCanAttachHSGToSafeReturnsFalseWithUnsafeSignerCounts() public {
+        ownerHat = 1;
+        signerHat = 2;
+        minThreshold = 1;
+        targetThreshold = 1;
+        maxSigners = 2;
+
+        // deploy a safe
+        initSafeOwners[0] = address(this);
+        mockIsWearerCall(address(this), signerHat, true);
+        safe = deploySafe(initSafeOwners, 1);
+
+        // deploy HSG
+        HatsSignerGate hsg = HatsSignerGate(
+            factory.deployHatsSignerGate(ownerHat, signerHat, address(safe), minThreshold, targetThreshold, maxSigners)
+        );
+
+        // add 2 owners and make them valid
+        bytes memory addOwnerData = abi.encodeWithSignature("addOwnerWithThreshold(address,uint256)", address(2), 1);
+        executeSafeTxFrom(address(this), addOwnerData, safe);
+        mockIsWearerCall(address(2), signerHat, true);
+
+        addOwnerData = abi.encodeWithSignature("addOwnerWithThreshold(address,uint256)", address(3), 1);
+        executeSafeTxFrom(address(this), addOwnerData, safe);
+        mockIsWearerCall(address(3), signerHat, true);
+
+        // canAttachHSGToSafe should return false
+        assertEq(hsg.validSignerCount(), 3, "valid signer count");
+        assertEq(hsg.maxSigners(), 2, "max signers");
+        assertFalse(
+            factory.canAttachHSGToSafe(HatsSignerGate(hsg)), "should return false with validSignerCount > maxSigners"
+        );
+    }
+
+    function testCanAttachHSGToSafeReturnsTrue() public {
+        ownerHat = 1;
+        signerHat = 2;
+        minThreshold = 2;
+        targetThreshold = 2;
+        maxSigners = 5;
+
+        // deploy a safe
+        initSafeOwners[0] = address(this);
+        mockIsWearerCall(address(this), signerHat, true);
+        safe = deploySafe(initSafeOwners, 1);
+
+        // deploy HSG
+        address hsg =
+            factory.deployHatsSignerGate(ownerHat, signerHat, address(safe), minThreshold, targetThreshold, maxSigners);
+
+        // canAttachHSGToSafe should return true
+        assertTrue(factory.canAttachHSGToSafe(HatsSignerGate(hsg)));
+    }
+
+    function testCanAttachMHSGToSafeReturnsFalseWithModule() public {
+        ownerHat = 1;
+        minThreshold = 2;
+        targetThreshold = 2;
+        maxSigners = 5;
+        // create signerHats array
+        uint256[] memory signerHats = new uint256[](1);
+        signerHats[0] = 2;
+
+        // deploy a safe
+        initSafeOwners[0] = address(this);
+        safe = deploySafe(initSafeOwners, 1);
+
+        // deploy MHSG
+        address mhsg = factory.deployMultiHatsSignerGate(
+            ownerHat, signerHats, address(safe), minThreshold, targetThreshold, maxSigners
+        );
+
+        // enable a module
+        bytes memory enableModuleData = abi.encodeWithSignature("enableModule(address)", address(0xf00baa)); // some devs are from Boston
+        executeSafeTxFrom(address(this), enableModuleData, safe);
+
+        // canAttachHSGToSafe should return false
+        assertFalse(factory.canAttachMHSGToSafe(MultiHatsSignerGate(mhsg)));
+    }
+
+    function testCanAttachMHSGToSafeReturnsFalseWithUnsafeSignerCounts() public {
+        ownerHat = 1;
+        minThreshold = 1;
+        targetThreshold = 1;
+        maxSigners = 2;
+        // create signerHats array
+        uint256[] memory signerHats = new uint256[](1);
+        signerHats[0] = 2;
+
+        // deploy a safe
+        initSafeOwners[0] = address(this);
+        mockIsWearerCall(address(this), signerHat, true);
+        safe = deploySafe(initSafeOwners, 1);
+
+        // deploy MHSG
+        MultiHatsSignerGate mhsg = MultiHatsSignerGate(
+            factory.deployMultiHatsSignerGate(
+                ownerHat, signerHats, address(safe), minThreshold, targetThreshold, maxSigners
+            )
+        );
+
+        // add 2 owners and make them valid
+        bytes memory addOwnerData = abi.encodeWithSignature("addOwnerWithThreshold(address,uint256)", address(2), 1);
+        executeSafeTxFrom(address(this), addOwnerData, safe);
+        mockIsWearerCall(address(2), signerHat, true);
+
+        addOwnerData = abi.encodeWithSignature("addOwnerWithThreshold(address,uint256)", address(3), 1);
+        executeSafeTxFrom(address(this), addOwnerData, safe);
+        mockIsWearerCall(address(3), signerHat, true);
+
+        // canAttachHSGToSafe should return false
+        assertEq(mhsg.validSignerCount(), 3, "valid signer count");
+        assertEq(mhsg.maxSigners(), 2, "max signers");
+        assertFalse(factory.canAttachMHSGToSafe(mhsg), "should return false with validSignerCount > maxSigners");
+    }
+
+    function testCanAttachMHSGToSafeReturnsTrue() public {
+        ownerHat = 1;
+        minThreshold = 2;
+        targetThreshold = 2;
+        maxSigners = 5;
+        // create signerHats array
+        uint256[] memory signerHats = new uint256[](1);
+        signerHats[0] = 2;
+
+        // deploy a safe
+        initSafeOwners[0] = address(this);
+        mockIsWearerCall(address(this), signerHat, true);
+        safe = deploySafe(initSafeOwners, 1);
+
+        // deploy MHSG
+        address mhsg = factory.deployMultiHatsSignerGate(
+            ownerHat, signerHats, address(safe), minThreshold, targetThreshold, maxSigners
+        );
+
+        // canAttachHSGToSafe should return true
+        assertTrue(factory.canAttachMHSGToSafe(MultiHatsSignerGate(mhsg)));
     }
 }


### PR DESCRIPTION
Addresses finding 93 by providing safe owners ability to check realtime if wiring up an (M)HSG to their safe would brick it. Also warns against unsafe wiring up in deploy function natspec.

https://github.com/sherlock-audit/2023-02-hats-judging/issues/93

Also includes some light general code cleanup.