### PR TITLE
Lockable

### DIFF
--- a/script/HatsSignerGate.s.sol
+++ b/script/HatsSignerGate.s.sol
@@ -89,7 +89,7 @@ contract DeployInstance is BaseScript {
   uint256 public targetThreshold;
   uint256 public maxSigners;
   address public safe;
-  string public version;
+  bool public locked;
 
   function prepare(
     bool _verbose,
@@ -100,7 +100,7 @@ contract DeployInstance is BaseScript {
     uint256 _targetThreshold,
     uint256 _maxSigners,
     address _safe,
-    // string memory _version,
+    bool _locked,
     uint256 _saltNonce
   ) public {
     verbose = _verbose;
@@ -111,7 +111,7 @@ contract DeployInstance is BaseScript {
     targetThreshold = _targetThreshold;
     maxSigners = _maxSigners;
     safe = _safe;
-    // version = _version;
+    locked = _locked;
     saltNonce = _saltNonce;
   }
 
@@ -128,7 +128,7 @@ contract DeployInstance is BaseScript {
   }
 
   function createDeployParams() public view returns (bytes memory) {
-    return abi.encode(ownerHat, signersHats, safe, minThreshold, targetThreshold, maxSigners, implementation);
+    return abi.encode(ownerHat, signersHats, safe, minThreshold, targetThreshold, maxSigners, locked, implementation);
   }
 
   function run() external returns (HatsSignerGate) {

--- a/script/HatsSignerGate.s.sol
+++ b/script/HatsSignerGate.s.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.13;
 import { Script, console2 } from "forge-std/Script.sol";
 import { stdJson } from "forge-std/StdJson.sol";
 import { HatsSignerGate } from "../src/HatsSignerGate.sol";
+import { IHatsSignerGate } from "../src/interfaces/IHatsSignerGate.sol";
 import { ModuleProxyFactory } from "../lib/zodiac/contracts/factory/ModuleProxyFactory.sol";
 
 contract BaseScript is Script {
@@ -127,8 +128,18 @@ contract DeployInstance is BaseScript {
     (,,,,, zodiacModuleFactory) = abi.decode(params, (address, address, address, address, address, address));
   }
 
-  function createDeployParams() public view returns (bytes memory) {
-    return abi.encode(ownerHat, signersHats, safe, minThreshold, targetThreshold, maxSigners, locked, implementation);
+  function setupParams() public view returns (IHatsSignerGate.SetupParams memory params) {
+    params = IHatsSignerGate.SetupParams({
+      ownerHat: ownerHat,
+      signerHats: signersHats,
+      safe: safe,
+      minThreshold: minThreshold,
+      targetThreshold: targetThreshold,
+      maxSigners: maxSigners,
+      locked: locked,
+      implementation: implementation
+    });
+    return params;
   }
 
   function run() external returns (HatsSignerGate) {
@@ -139,7 +150,7 @@ contract DeployInstance is BaseScript {
     vm.startBroadcast(deployer);
 
     instance = ModuleProxyFactory(zodiacModuleFactory).deployModule(
-      address(implementation), abi.encodeWithSignature("setUp(bytes)", createDeployParams()), saltNonce
+      address(implementation), abi.encodeWithSignature("setUp(bytes)", abi.encode(setupParams())), saltNonce
     );
 
     vm.stopBroadcast();

--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -69,11 +69,13 @@ contract HatsSignerGate is IHatsSignerGate, SafeDeployer, BaseGuard, SignatureDe
                               MODIFIERS
   //////////////////////////////////////////////////////////////*/
 
+  /// @notice Only the wearer of the owner hat can change this contract's settings
   modifier onlyOwner() {
     if (!HATS.isWearerOfHat(msg.sender, ownerHat)) revert NotOwnerHatWearer();
     _;
   }
 
+  /// @notice Changes to settings can only be made if the contract is not locked
   modifier onlyUnlocked() {
     if (locked) revert Locked();
     _;
@@ -96,6 +98,7 @@ contract HatsSignerGate is IHatsSignerGate, SafeDeployer, BaseGuard, SignatureDe
     // set the implementation's owner hat to a nonexistent hat to prevent state changes to the implementation
     ownerHat = 1;
 
+    // set the implementation's version; this will also be set on each instance deployed from this implementation
     version = _version;
   }
 
@@ -254,7 +257,8 @@ contract HatsSignerGate is IHatsSignerGate, SafeDeployer, BaseGuard, SignatureDe
                         OWNER FUNCTIONS
   //////////////////////////////////////////////////////////////*/
 
-  /// @notice Locks the contract, preventing any further changes to the contract's settings
+  /// @notice Irreversibly locks the contract, preventing any further changes to the contract's settings.
+  /// @dev Only callable by a wearer of the owner hat, and only if the contract is not locked.
   function lock() public onlyOwner onlyUnlocked {
     _lock();
   }

--- a/src/interfaces/IHatsSignerGate.sol
+++ b/src/interfaces/IHatsSignerGate.sol
@@ -16,6 +16,9 @@ library HSGEvents {
 
   /// @notice Emitted when the owner hat is updated
   event OwnerHatUpdated(uint256 ownerHat);
+
+  /// @notice Emitted when the contract is locked, preventing any further changes to settings
+  event Locked();
 }
 
 /// @notice Interface for the HatsSignerGate contract
@@ -96,6 +99,9 @@ interface IHatsSignerGate {
 
   /// @notice Cannot attach to a Safe with existing modules
   error CannotAttachToSafe();
+
+  /// @notice Owner cannot change settings once the contract is locked
+  error Locked();
 
   /*//////////////////////////////////////////////////////////////
                               FUNCTIONS

--- a/src/interfaces/IHatsSignerGate.sol
+++ b/src/interfaces/IHatsSignerGate.sol
@@ -24,6 +24,30 @@ library HSGEvents {
 /// @notice Interface for the HatsSignerGate contract
 interface IHatsSignerGate {
   /*//////////////////////////////////////////////////////////////
+                            STRUCTS
+  //////////////////////////////////////////////////////////////*/
+
+  /// @notice Struct for the parameters passed to the `setUp` function
+  /// @param ownerHat The ID of the owner hat
+  /// @param signerHats The IDs of the signer hats
+  /// @param safe The address of the safe
+  /// @param minThreshold The minimum signature threshold
+  /// @param targetThreshold The target signature threshold
+  /// @param maxSigners The maximum number of signers
+  /// @param locked Whether the contract is locked
+  /// @param implementation The address of the HatsSignerGate implementation
+  struct SetupParams {
+    uint256 ownerHat;
+    uint256[] signerHats;
+    address safe;
+    uint256 minThreshold;
+    uint256 targetThreshold;
+    uint256 maxSigners;
+    bool locked;
+    address implementation;
+  }
+
+  /*//////////////////////////////////////////////////////////////
                             CUSTOM ERRORS
   //////////////////////////////////////////////////////////////*/
 
@@ -113,6 +137,8 @@ interface IHatsSignerGate {
   function claimSigner(uint256 _hatId) external;
   function removeSigner(address _signer) external;
   function reconcileSignerCount() external;
+  function lock() external;
+  function setOwnerHat(uint256 _ownerHat) external;
   function setTargetThreshold(uint256 _targetThreshold) external;
   function setMinThreshold(uint256 _minThreshold) external;
   function addSignerHats(uint256[] calldata _newSignerHats) external;

--- a/test/TestSuite.sol
+++ b/test/TestSuite.sol
@@ -238,6 +238,7 @@ contract TestSuite is SafeTestHelpers {
   uint256 public minThreshold;
   uint256 public targetThreshold;
   uint256 public maxSigners;
+  bool public locked;
   string public version;
 
   // Utility variables
@@ -318,6 +319,7 @@ contract TestSuite is SafeTestHelpers {
     uint256 _targetThreshold,
     uint256 _maxSigners,
     address _safe,
+    bool _locked,
     bytes4 _expectedError,
     bool _verbose
   ) internal returns (HatsSignerGate) {
@@ -332,6 +334,7 @@ contract TestSuite is SafeTestHelpers {
       _targetThreshold,
       _maxSigners,
       _safe,
+      _locked,
       TEST_SALT_NONCE
     );
 
@@ -349,6 +352,7 @@ contract TestSuite is SafeTestHelpers {
     uint256 _minThreshold,
     uint256 _targetThreshold,
     uint256 _maxSigners,
+    bool _locked,
     bool _verbose
   ) internal returns (HatsSignerGate _hatsSignerGate, ISafe _safe) {
     // create the instance deployer
@@ -362,6 +366,7 @@ contract TestSuite is SafeTestHelpers {
       _targetThreshold,
       _maxSigners,
       address(0),
+      _locked,
       TEST_SALT_NONCE
     );
     _hatsSignerGate = instanceDeployer.run();
@@ -416,6 +421,14 @@ contract WithHSGInstanceTest is TestSuite {
   function setUp() public override {
     super.setUp();
 
-    (hatsSignerGate, safe) = _deployHSGAndSafe(ownerHat, signerHats, minThreshold, targetThreshold, maxSigners, false);
+    (hatsSignerGate, safe) = _deployHSGAndSafe({
+      _ownerHat: ownerHat,
+      _signerHats: signerHats,
+      _minThreshold: minThreshold,
+      _targetThreshold: targetThreshold,
+      _maxSigners: maxSigners,
+      _locked: false,
+      _verbose: false
+    });
   }
 }


### PR DESCRIPTION
This PR makes HSG lockable so that the owner can prevent any further changes to parameters and settings. 

- closes #40 
- adds a `SetupParams` struct to the initializer instead of arbitrary bytes

Locking will incorporate the following owner authorities:
- setOwnerHat
- lock
- setMinThreshold
- setTargetThreshold
- addSignerHats

The above will likely later also include...
- #39 
- #37 
- #42 
- #41 
