### PR TITLE
Set max signers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The wearer of the `ownerHat` can make the following changes to Hats Signer Gate:
 2. Set the acceptable multisig threshold range by changing `minThreshold` and `targetThreshold`
 3. Add other Zodiac modules to the multisig
 4. Add other Hats as valid signer Hats
+5. Change the `maxSigners`
 
 ### Deploying New Instances
 

--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -132,7 +132,7 @@ contract HatsSignerGate is IHatsSignerGate, SafeDeployer, BaseGuard, SignatureDe
     // set the instance's safe and signer parameters
     safe = ISafe(params.safe);
     _addSignerHats(params.signerHats);
-    maxSigners = params.maxSigners;
+    _setMaxSigners(params.maxSigners, params.targetThreshold);
     _setTargetThreshold(params.targetThreshold);
     _setMinThreshold(params.minThreshold);
 
@@ -280,6 +280,14 @@ contract HatsSignerGate is IHatsSignerGate, SafeDeployer, BaseGuard, SignatureDe
   /// @param _minThreshold The new minimum threshold
   function setMinThreshold(uint256 _minThreshold) public onlyOwner onlyUnlocked {
     _setMinThreshold(_minThreshold);
+  }
+
+  /// @notice Sets a new maximum number of signers
+  /// @dev Only callable by a wearer of the owner hat, and only if the contract is not locked.
+  /// Reverts if `_maxSigners` is less than the current number of valid signers or lower than `targetThreshold`
+  /// @param _maxSigners The new maximum number of signers
+  function setMaxSigners(uint256 _maxSigners) public onlyOwner onlyUnlocked {
+    _setMaxSigners(_maxSigners, targetThreshold);
   }
 
   /*//////////////////////////////////////////////////////////////
@@ -610,6 +618,19 @@ contract HatsSignerGate is IHatsSignerGate, SafeDeployer, BaseGuard, SignatureDe
         ++i;
       }
     }
+  }
+
+  /// @dev Internal function to set a new maximum number of signers
+  /// Reverts if `_maxSigners` is less than the current number of valid signers or lower than `targetThreshold`
+  /// @param _maxSigners The new maximum number of signers
+  /// @param _targetThreshold The existing target threshold
+  function _setMaxSigners(uint256 _maxSigners, uint256 _targetThreshold) internal {
+    if (_maxSigners < validSignerCount() || _maxSigners < _targetThreshold) {
+      revert InvalidMaxSigners();
+    }
+
+    maxSigners = _maxSigners;
+    emit HSGEvents.MaxSignersSet(_maxSigners);
   }
 
   /// @notice Internal function that adds `_signer` as an owner on `safe`, updating the threshold if appropriate

--- a/src/interfaces/IHatsSignerGate.sol
+++ b/src/interfaces/IHatsSignerGate.sol
@@ -17,6 +17,9 @@ library HSGEvents {
   /// @notice Emitted when the owner hat is updated
   event OwnerHatUpdated(uint256 ownerHat);
 
+  /// @notice Emitted when the maximum number of signers is set
+  event MaxSignersSet(uint256 maxSigners);
+
   /// @notice Emitted when the contract is locked, preventing any further changes to settings
   event Locked();
 }
@@ -82,6 +85,9 @@ interface IHatsSignerGate {
 
   /// @notice Min threshold cannot be higher than `maxSigners` or `targetThreshold`
   error InvalidMinThreshold();
+
+  /// @notice Max signers cannot be less than `targetThreshold` or `validSignerCount`
+  error InvalidMaxSigners();
 
   /// @notice Signers already on the `safe` cannot claim twice
   error SignerAlreadyClaimed(address signer);


### PR DESCRIPTION
This PR adds an affordance for owners to set and update the `maxSigners` parameter (as long as the contract is not locked). This helps alleviate an existing practice where HSG deployers often set `maxSigners` higher than desired in the present in order to ensure that future changes don't cause problems.

Closes #37 