### PR TITLE
remove maxSigners

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ The wearer of the `ownerHat` can make the following changes to Hats Signer Gate:
 2. Set the acceptable multisig threshold range by changing `minThreshold` and `targetThreshold`
 3. Add other Zodiac modules to the multisig
 4. Add other Hats as valid signer Hats
-5. Change the `maxSigners`
 
 ### Deploying New Instances
 

--- a/gasreport.ansi
+++ b/gasreport.ansi
@@ -1,143 +1,141 @@
-No files changed, compilation skipped
-
-Ran 3 tests for test/HatsSignerGate.t.sol:MigratingHSG
-[PASS] test_happy() (gas: 210)
-[PASS] test_revert_locked() (gas: 231)
-[PASS] test_revert_nonOwner() (gas: 231)
-Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 392.35ms (800.88µs CPU time)
+Compiling 4 files with Solc 0.8.20
+Solc 0.8.20 finished in 8.16s
+Compiler run successful!
 
 Ran 2 tests for test/HatsSignerGate.t.sol:GuardFunctionAuth
-[PASS] testCannotCallCheckAfterExecutionFromNonSafe() (gas: 34590)
-[PASS] testCannotCallCheckTransactionFromNonSafe() (gas: 38145)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 392.33ms (459.33µs CPU time)
-
-Ran 4 tests for test/HatsSignerGate.t.sol:SettingMinThreshold
-[PASS] testNonOwnerCannotSetMinThreshold() (gas: 61408)
-[PASS] testSetInvalidMinThreshold() (gas: 62287)
-[PASS] testSetMinThreshold() (gas: 156079)
-[PASS] test_revert_locked() (gas: 109987)
-Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 517.48ms (125.96ms CPU time)
+[PASS] testCannotCallCheckAfterExecutionFromNonSafe() (gas: 34657)
+[PASS] testCannotCallCheckTransactionFromNonSafe() (gas: 38123)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 379.15ms (1.43ms CPU time)
 
 Ran 3 tests for test/HatsSignerGate.t.sol:DetachingHSG
-[PASS] test_happy() (gas: 90964)
-[PASS] test_revert_locked() (gas: 127375)
-[PASS] test_revert_nonOwner() (gas: 73234)
-Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 517.82ms (125.88ms CPU time)
+[PASS] test_happy() (gas: 91086)
+[PASS] test_revert_locked() (gas: 127331)
+[PASS] test_revert_nonOwner() (gas: 73190)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 380.91ms (3.86ms CPU time)
 
-Ran 5 tests for test/HatsSignerGate.t.sol:AddingSigners
-[PASS] testAddSingleSigner() (gas: 268776)
-[PASS] testAddThreeSigners() (gas: 772691)
-[PASS] testAddTooManySigners() (gas: 1550882)
-[PASS] test_Multi_AddSingleSigner() (gas: 277106)
-[PASS] test_Multi_AddTwoSigners_DifferentHats() (gas: 533991)
-Suite result: ok. 5 passed; 0 failed; 0 skipped; finished in 526.33ms (134.25ms CPU time)
+Ran 4 tests for test/HatsSignerGate.t.sol:SettingMinThreshold
+[PASS] testNonOwnerCannotSetMinThreshold() (gas: 61429)
+[PASS] testSetInvalidMinThreshold() (gas: 60137)
+[PASS] testSetMinThreshold() (gas: 151859)
+[PASS] test_revert_locked() (gas: 109965)
+Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 382.48ms (6.66ms CPU time)
+
+Ran 3 tests for test/HatsSignerGate.t.sol:MigratingHSG
+[PASS] test_happy() (gas: 151577)
+[PASS] test_revert_locked() (gas: 112373)
+[PASS] test_revert_nonOwner() (gas: 58232)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 382.72ms (3.13ms CPU time)
+
+Ran 5 tests for test/HatsSignerGate.t.sol:ClaimingSignerFor
+[PASS] test_happy() (gas: 319243)
+[PASS] test_revert_alreadyClaimed() (gas: 404040)
+[PASS] test_revert_invalidSigner() (gas: 225401)
+[PASS] test_revert_invalidSignerHat() (gas: 271466)
+[PASS] test_revert_notClaimableFor() (gas: 283302)
+Suite result: ok. 5 passed; 0 failed; 0 skipped; finished in 510.39ms (135.20ms CPU time)
+
+Ran 4 tests for test/HatsSignerGate.t.sol:AddingSigners
+[PASS] testAddSingleSigner() (gas: 266837)
+[PASS] testAddThreeSigners() (gas: 766843)
+[PASS] test_Multi_AddSingleSigner() (gas: 275167)
+[PASS] test_Multi_AddTwoSigners_DifferentHats() (gas: 530107)
+Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 514.00ms (260.46ms CPU time)
 
 Ran 7 tests for test/HatsSignerGate.t.sol:RemovingSigners
-[PASS] testCanRemoveInvalidSigner1() (gas: 401042)
-[PASS] testCanRemoveInvalidSignerAfterReconcile2Signers() (gas: 750890)
-[PASS] testCanRemoveInvalidSignerAfterReconcile3PLusSigners() (gas: 1023390)
-[PASS] testCanRemoveInvalidSignerWhenMultipleSigners() (gas: 644646)
-[PASS] testCannotRemoveValidSigner() (gas: 326451)
-[PASS] test_Multi_CanRemoveInvalidSigner1() (gas: 414240)
-[PASS] test_Multi_CannotRemoveValidSigner() (gas: 337628)
-Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 527.01ms (135.04ms CPU time)
-
-Ran 7 tests for test/HatsSignerGate.t.sol:ConstrainingSigners
-[PASS] testCannotDecreaseThreshold() (gas: 1197333)
-[PASS] testCannotDisableGuard() (gas: 917630)
-[PASS] testCannotDisableModule() (gas: 945427)
-[PASS] testCannotIncreaseThreshold() (gas: 1197353)
-[PASS] testSignersCannotAddOwners() (gas: 1241415)
-[PASS] testSignersCannotRemoveOwners() (gas: 1209834)
-[PASS] testSignersCannotSwapOwners() (gas: 1241964)
-Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 535.82ms (270.72ms CPU time)
+[PASS] testCanRemoveInvalidSigner1() (gas: 399279)
+[PASS] testCanRemoveInvalidSignerAfterReconcile2Signers() (gas: 745240)
+[PASS] testCanRemoveInvalidSignerAfterReconcile3PLusSigners() (gas: 1015577)
+[PASS] testCanRemoveInvalidSignerWhenMultipleSigners() (gas: 640866)
+[PASS] testCannotRemoveValidSigner() (gas: 324512)
+[PASS] test_Multi_CanRemoveInvalidSigner1() (gas: 412477)
+[PASS] test_Multi_CannotRemoveValidSigner() (gas: 335756)
+Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 517.54ms (141.55ms CPU time)
 
 Ran 6 tests for test/HatsSignerGate.t.sol:ExecutingTransactions
-[PASS] testExecByLessThanMinThresholdReverts() (gas: 885098)
-[PASS] testExecTxByHatWearers() (gas: 1302964)
-[PASS] testExecTxByNonHatWearersReverts() (gas: 1302906)
-[PASS] testExecTxByTooFewOwnersReverts() (gas: 501495)
-[PASS] test_Multi_ExecTxByHatWearers() (gas: 1342519)
-[PASS] test_Multi_ExecTxByNonHatWearersReverts() (gas: 1344631)
-Suite result: ok. 6 passed; 0 failed; 0 skipped; finished in 537.87ms (142.66ms CPU time)
+[PASS] testExecByLessThanMinThresholdReverts() (gas: 876991)
+[PASS] testExecTxByHatWearers() (gas: 1295054)
+[PASS] testExecTxByNonHatWearersReverts() (gas: 1294922)
+[PASS] testExecTxByTooFewOwnersReverts() (gas: 497379)
+[PASS] test_Multi_ExecTxByHatWearers() (gas: 1334609)
+[PASS] test_Multi_ExecTxByNonHatWearersReverts() (gas: 1336647)
+Suite result: ok. 6 passed; 0 failed; 0 skipped; finished in 520.71ms (275.40ms CPU time)
 
-Ran 13 tests for test/HatsSignerGate.attacks.t.sol:AttacksScenarios
-[PASS] testAttackOnMaxSigner2Fails() (gas: 2813962)
-[PASS] testAttackOnMaxSignerFails() (gas: 1988437)
-[PASS] testAttackerCannotExploitSigHandlingDifferences() (gas: 1735881)
-[PASS] testCanClaimToReplaceInvalidSignerAtMaxSigner() (gas: 1609394)
-[PASS] testCannotClaimSignerIfNoInvalidSigners() (gas: 1793936)
-[PASS] testRemoveSignerCorrectlyUpdates() (gas: 1587817)
-[PASS] testSetTargetThresholdUpdatesThresholdCorrectly() (gas: 1559643)
-[PASS] testSetTargetTresholdCannotSetBelowMinThreshold() (gas: 70973)
-[PASS] testSignersCannotAddNewModules() (gas: 962319)
-[PASS] testSignersCannotReenterCheckTransactionToAddOwners() (gas: 1408819)
-[PASS] testTargetSigAttackFails() (gas: 2310608)
-[PASS] testValidSignersCanClaimAfterLastMaxSignerLosesHat() (gas: 1630337)
-[PASS] testValidSignersCanClaimAfterMaxSignerLosesHat() (gas: 1702733)
-Suite result: ok. 13 passed; 0 failed; 0 skipped; finished in 537.97ms (184.20ms CPU time)
+Ran 7 tests for test/HatsSignerGate.t.sol:ConstrainingSigners
+[PASS] testCannotDecreaseThreshold() (gas: 1189360)
+[PASS] testCannotDisableGuard() (gas: 911623)
+[PASS] testCannotDisableModule() (gas: 939594)
+[PASS] testCannotIncreaseThreshold() (gas: 1189358)
+[PASS] testSignersCannotAddOwners() (gas: 1233420)
+[PASS] testSignersCannotRemoveOwners() (gas: 1201906)
+[PASS] testSignersCannotSwapOwners() (gas: 1233969)
+Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 520.71ms (152.41ms CPU time)
+
+Ran 8 tests for test/HatsSignerGate.attacks.t.sol:AttacksScenarios
+[PASS] testAttackerCannotExploitSigHandlingDifferences() (gas: 1723905)
+[PASS] testCanClaimToReplaceInvalidSignerAtMaxSigner() (gas: 1608698)
+[PASS] testRemoveSignerCorrectlyUpdates() (gas: 1575859)
+[PASS] testSetTargetThresholdUpdatesThresholdCorrectly() (gas: 1545610)
+[PASS] testSetTargetTresholdCannotSetBelowMinThreshold() (gas: 70984)
+[PASS] testSignersCannotAddNewModules() (gas: 956462)
+[PASS] testSignersCannotReenterCheckTransactionToAddOwners() (gas: 1400594)
+[PASS] testTargetSigAttackFails() (gas: 2294663)
+Suite result: ok. 8 passed; 0 failed; 0 skipped; finished in 520.69ms (161.47ms CPU time)
 
 Ran 4 tests for test/HatsSignerGate.t.sol:AddingSignerHats
-[PASS] test_Multi_NonOwnerCannotAddSignerHats() (gas: 56756)
-[PASS] test_Multi_OwnerCanAddSignerHats(uint256) (runs: 257, μ: 284902, ~: 109053)
-[PASS] test_Multi_OwnerCanAddSignerHats1() (gas: 85612)
-[PASS] test_revert_locked() (gas: 110993)
-Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 597.03ms (204.55ms CPU time)
+[PASS] test_Multi_NonOwnerCannotAddSignerHats() (gas: 56734)
+[PASS] test_Multi_OwnerCanAddSignerHats(uint256) (runs: 259, μ: 321587, ~: 109031)
+[PASS] test_Multi_OwnerCanAddSignerHats1() (gas: 85590)
+[PASS] test_revert_locked() (gas: 110971)
+Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 585.56ms (209.84ms CPU time)
 
 Ran 4 tests for test/HatsSignerGate.t.sol:ClaimingSigners
-[PASS] testClaimSigner() (gas: 260999)
-[PASS] testNonHatWearerCannotClaimSigner() (gas: 130898)
-[PASS] testOwnerClaimSignerReverts() (gas: 600858)
-[PASS] test_Multi_NonHatWearerCannotClaimSigner(uint256) (runs: 256, μ: 133743, ~: 133743)
-Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 709.16ms (317.74ms CPU time)
-
-Ran 4 tests for test/HatsSignerGate.t.sol:Deployment
-[PASS] test_andSafe(bool) (runs: 257, μ: 2505088, ~: 2495481)
-[PASS] test_onlyHSG(bool) (runs: 257, μ: 2451149, ~: 2450647)
-[PASS] test_revert_onlyHSG_existingSafeHasModules() (gas: 2191299)
-[PASS] test_revert_reinitializeImplementation() (gas: 59865)
-Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 749.38ms (546.71ms CPU time)
-
-Ran 8 tests for test/HatsSignerGate.t.sol:SettingMaxSigners
-[PASS] test_aboveBothCriteria() (gas: 131323)
-[PASS] test_aboveValidSignerCount_atTargetThreshold() (gas: 214876)
-[PASS] test_atValidSignerCount_aboveTargetThreshold() (gas: 875430)
-[PASS] test_revert_invalidMaxSigners_belowBothCriteria() (gas: 613332)
-[PASS] test_revert_invalidMaxSigners_belowTargetThreshold() (gas: 129611)
-[PASS] test_revert_invalidMaxSigners_belowValidSignerCount() (gas: 878266)
-[PASS] test_revert_locked() (gas: 119114)
-[PASS] test_revert_nonOwner() (gas: 65028)
-Suite result: ok. 8 passed; 0 failed; 0 skipped; finished in 360.78ms (8.09ms CPU time)
+[PASS] test_happy() (gas: 259015)
+[PASS] test_revert_alreadyClaimed() (gas: 594831)
+[PASS] test_revert_invalidSigner() (gas: 128783)
+[PASS] test_revert_multi_invalidSigner(uint256) (runs: 257, μ: 131629, ~: 131629)
+Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 682.87ms (306.61ms CPU time)
 
 Ran 5 tests for test/HatsSignerGate.t.sol:SettingTargetThreshold
-[PASS] testNonOwnerHatWearerCannotSetTargetThreshold() (gas: 73601)
-[PASS] testSetTargetThreshold() (gas: 350057)
-[PASS] testSetTargetThreshold3of4() (gas: 1153565)
-[PASS] testSetTargetThreshold4of4() (gas: 1153550)
-[PASS] test_revert_locked() (gas: 109964)
-Suite result: ok. 5 passed; 0 failed; 0 skipped; finished in 236.19ms (7.18ms CPU time)
+[PASS] testNonOwnerHatWearerCannotSetTargetThreshold() (gas: 73646)
+[PASS] testSetTargetThreshold() (gas: 345982)
+[PASS] testSetTargetThreshold3of4() (gas: 1143634)
+[PASS] testSetTargetThreshold4of4() (gas: 1143705)
+[PASS] test_revert_locked() (gas: 109987)
+Suite result: ok. 5 passed; 0 failed; 0 skipped; finished in 319.08ms (7.50ms CPU time)
+
+Ran 3 tests for test/HatsSignerGate.t.sol:SettingClaimableFor
+[PASS] test_happy(bool) (runs: 259, μ: 63227, ~: 64595)
+[PASS] test_revert_locked() (gas: 119322)
+[PASS] test_revert_nonOwner() (gas: 65203)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 209.74ms (26.98ms CPU time)
+
+Ran 3 tests for test/HatsSignerGate.t.sol:Deployment
+[PASS] test_andSafe(bool,bool) (runs: 259, μ: 2473691, ~: 2478879)
+[PASS] test_onlyHSG(bool,bool) (runs: 259, μ: 2397306, ~: 2397783)
+[PASS] test_revert_reinitializeImplementation() (gas: 57512)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 520.56ms (350.15ms CPU time)
 | script/HatsSignerGate.s.sol:DeployImplementation contract |                 |         |         |         |         |
 |-----------------------------------------------------------|-----------------|---------|---------|---------|---------|
 | Deployment Cost                                           | Deployment Size |         |         |         |         |
-| 5716398                                                   | 26547           |         |         |         |         |
+| 5574775                                                   | 25877           |         |         |         |         |
 | Function Name                                             | min             | avg     | median  | max     | # calls |
-| hats                                                      | 401             | 401     | 401     | 401     | 75      |
-| prepare                                                   | 32744           | 32744   | 32744   | 32744   | 75      |
-| run                                                       | 4170211         | 4170211 | 4170211 | 4170211 | 75      |
-| safeFallbackLibrary                                       | 347             | 347     | 347     | 347     | 75      |
-| safeMultisendLibrary                                      | 346             | 346     | 346     | 346     | 75      |
-| safeProxyFactory                                          | 348             | 348     | 348     | 348     | 75      |
-| safeSingleton                                             | 391             | 391     | 391     | 391     | 75      |
-| zodiacModuleFactory                                       | 369             | 369     | 369     | 369     | 75      |
+| hats                                                      | 401             | 401     | 401     | 401     | 68      |
+| prepare                                                   | 32744           | 32744   | 32744   | 32744   | 68      |
+| run                                                       | 4035840         | 4035840 | 4035840 | 4035840 | 68      |
+| safeFallbackLibrary                                       | 347             | 347     | 347     | 347     | 68      |
+| safeMultisendLibrary                                      | 346             | 346     | 346     | 346     | 68      |
+| safeProxyFactory                                          | 348             | 348     | 348     | 348     | 68      |
+| safeSingleton                                             | 391             | 391     | 391     | 391     | 68      |
+| zodiacModuleFactory                                       | 369             | 369     | 369     | 369     | 68      |
 
 
 | script/HatsSignerGate.s.sol:DeployInstance contract |                 |        |        |        |         |
 |-----------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                     | Deployment Size |        |        |        |         |
-| 1282689                                             | 5576            |        |        |        |         |
+| 1308948                                             | 5701            |        |        |        |         |
 | Function Name                                       | min             | avg    | median | max    | # calls |
-| prepare                                             | 298342          | 311230 | 318254 | 318494 | 584     |
-| run                                                 | 174921          | 654134 | 777305 | 778317 | 584     |
+| prepare                                             | 276306          | 291608 | 296230 | 296470 | 580     |
+| run                                                 | 441735          | 606544 | 738761 | 739773 | 580     |
 
 
 | src/HatsSignerGate.sol:HatsSignerGate contract |                 |        |        |         |         |
@@ -145,31 +143,33 @@ Suite result: ok. 5 passed; 0 failed; 0 skipped; finished in 236.19ms (7.18ms CP
 | Deployment Cost                                | Deployment Size |        |        |         |         |
 | 0                                              | 0               |        |        |         |         |
 | Function Name                                  | min             | avg    | median | max     | # calls |
-| HATS                                           | 293             | 293    | 293    | 293     | 512     |
-| addSignerHats                                  | 21712           | 237909 | 70804  | 2156887 | 259     |
-| checkAfterExecution                            | 2523            | 22145  | 22563  | 35403   | 11      |
-| checkTransaction                               | 3786            | 107765 | 119323 | 146225  | 19      |
-| claimSigner                                    | 54068           | 81724  | 54068  | 188576  | 398     |
-| detachHSG                                      | 21452           | 37897  | 23578  | 68663   | 3       |
-| implementation                                 | 392             | 392    | 392    | 392     | 512     |
-| lock                                           | 27360           | 27360  | 27360  | 27360   | 5       |
+| HATS                                           | 271             | 271    | 271    | 271     | 512     |
+| addSignerHats                                  | 21690           | 276233 | 70782  | 2270242 | 259     |
+| checkAfterExecution                            | 2590            | 22282  | 22745  | 35522   | 11      |
+| checkTransaction                               | 3764            | 105865 | 117190 | 144200  | 19      |
+| claimSigner                                    | 51953           | 72189  | 51953  | 169695  | 352     |
+| claimSignerFor                                 | 2595            | 63345  | 48859  | 121037  | 6       |
+| claimableFor                                   | 378             | 383    | 378    | 2378    | 772     |
+| detachHSG                                      | 21430           | 37931  | 23556  | 68807   | 3       |
+| implementation                                 | 436             | 436    | 436    | 436     | 512     |
+| lock                                           | 27360           | 27360  | 27360  | 27360   | 6       |
 | locked                                         | 410             | 410    | 410    | 410     | 512     |
-| maxSigners                                     | 385             | 404    | 385    | 2385    | 525     |
+| migrateToNewHSG                                | 21548           | 53400  | 23674  | 114980  | 3       |
 | minThreshold                                   | 384             | 395    | 384    | 2384    | 516     |
-| ownerHat                                       | 407             | 407    | 407    | 407     | 512     |
-| reconcileSignerCount                           | 72099           | 91447  | 97075  | 111600  | 10      |
-| removeSigner                                   | 21690           | 76064  | 86633  | 121594  | 8       |
-| safe                                           | 404             | 404    | 404    | 404     | 839     |
-| setMaxSigners                                  | 21484           | 57055  | 58690  | 88643   | 8       |
-| setMinThreshold                                | 21507           | 26751  | 25769  | 33961   | 4       |
-| setTargetThreshold                             | 21463           | 73248  | 60824  | 133605  | 12      |
-| supportsInterface                              | 399             | 399    | 399    | 399     | 327     |
-| targetThreshold                                | 361             | 387    | 361    | 2361    | 525     |
-| validSignerCount                               | 5588            | 19525  | 24515  | 37520   | 36      |
-| validSignerHats                                | 510             | 510    | 510    | 510     | 2560    |
-| version                                        | 1318            | 2382   | 3318   | 3318    | 1095    |
+| ownerHat                                       | 385             | 385    | 385    | 385     | 512     |
+| reconcileSignerCount                           | 69988           | 80974  | 72157  | 109597  | 4       |
+| removeSigner                                   | 21690           | 76176  | 86787  | 121741  | 8       |
+| safe                                           | 404             | 404    | 404    | 404     | 833     |
+| setClaimableFor                                | 21549           | 26438  | 27793  | 27793   | 264     |
+| setMinThreshold                                | 21485           | 25665  | 24683  | 31811   | 4       |
+| setTargetThreshold                             | 21508           | 72924  | 58754  | 131643  | 11      |
+| supportsInterface                              | 399             | 399    | 399    | 399     | 322     |
+| targetThreshold                                | 361             | 372    | 361    | 2361    | 519     |
+| validSignerCount                               | 5654            | 16271  | 14629  | 29654   | 23      |
+| validSignerHats                                | 488             | 488    | 488    | 488     | 2560    |
+| version                                        | 1296            | 2358   | 3296   | 3296    | 1092    |
 
 
 
 
-Ran 14 test suites in 806.11ms (7.14s CPU time): 75 tests passed, 0 failed, 0 skipped (75 total tests)
+Ran 15 test suites in 957.57ms (6.95s CPU time): 68 tests passed, 0 failed, 0 skipped (68 total tests)

--- a/script/HatsSignerGate.s.sol
+++ b/script/HatsSignerGate.s.sol
@@ -88,7 +88,6 @@ contract DeployInstance is BaseScript {
   uint256[] public signersHats;
   uint256 public minThreshold;
   uint256 public targetThreshold;
-  uint256 public maxSigners;
   address public safe;
   bool public locked;
   bool public claimableFor;
@@ -100,7 +99,6 @@ contract DeployInstance is BaseScript {
     uint256[] memory _signersHats,
     uint256 _minThreshold,
     uint256 _targetThreshold,
-    uint256 _maxSigners,
     address _safe,
     bool _locked,
     bool _claimableFor,
@@ -112,7 +110,6 @@ contract DeployInstance is BaseScript {
     signersHats = _signersHats;
     minThreshold = _minThreshold;
     targetThreshold = _targetThreshold;
-    maxSigners = _maxSigners;
     safe = _safe;
     locked = _locked;
     claimableFor = _claimableFor;
@@ -138,7 +135,6 @@ contract DeployInstance is BaseScript {
       safe: safe,
       minThreshold: minThreshold,
       targetThreshold: targetThreshold,
-      maxSigners: maxSigners,
       locked: locked,
       claimableFor: claimableFor,
       implementation: implementation

--- a/src/interfaces/IHatsSignerGate.sol
+++ b/src/interfaces/IHatsSignerGate.sol
@@ -17,9 +17,6 @@ library HSGEvents {
   /// @notice Emitted when the owner hat is updated
   event OwnerHatUpdated(uint256 ownerHat);
 
-  /// @notice Emitted when the maximum number of signers is set
-  event MaxSignersSet(uint256 maxSigners);
-
   /// @notice Emitted when the contract is locked, preventing any further changes to settings
   event Locked();
 
@@ -45,7 +42,6 @@ interface IHatsSignerGate {
   /// @param safe The address of the safe
   /// @param minThreshold The minimum signature threshold
   /// @param targetThreshold The target signature threshold
-  /// @param maxSigners The maximum number of signers
   /// @param locked Whether the contract is locked
   /// @param claimableFor Whether signer permissions can be claimed on behalf of valid hat wearers
   /// @param implementation The address of the HatsSignerGate implementation
@@ -55,7 +51,6 @@ interface IHatsSignerGate {
     address safe;
     uint256 minThreshold;
     uint256 targetThreshold;
-    uint256 maxSigners;
     bool locked;
     bool claimableFor;
     address implementation;
@@ -83,22 +78,11 @@ interface IHatsSignerGate {
   /// @notice Can't remove a signer if they're still wearing the signer hat
   error StillWearsSignerHat(address signer);
 
-  /// @notice Can never have more signers than designated by `maxSigners`
-  error MaxSignersReached();
-
-  /// @notice Emitted when a valid signer attempts `claimSigner` but there are already `maxSigners` signers
-  /// @dev This will only occur if `signerCount` is out of sync with the current number of valid signers, which can be
-  /// resolved by calling `reconcileSignerCount`
-  error NoInvalidSignersToReplace();
-
-  /// @notice Target threshold must be lower than `maxSigners`
+  /// @notice Target threshold must greater than `minThreshold`
   error InvalidTargetThreshold();
 
-  /// @notice Min threshold cannot be higher than `maxSigners` or `targetThreshold`
+  /// @notice Min threshold cannot be higher than `targetThreshold`
   error InvalidMinThreshold();
-
-  /// @notice Max signers cannot be less than `targetThreshold` or `validSignerCount`
-  error InvalidMaxSigners();
 
   /// @notice Signers already on the `safe` cannot claim twice
   error SignerAlreadyClaimed(address signer);
@@ -185,6 +169,5 @@ interface IHatsSignerGate {
   function safe() external view returns (ISafe);
   function minThreshold() external view returns (uint256);
   function targetThreshold() external view returns (uint256);
-  function maxSigners() external view returns (uint256);
   function version() external view returns (string memory);
 }

--- a/src/lib/SafeManagerLib.sol
+++ b/src/lib/SafeManagerLib.sol
@@ -249,9 +249,6 @@ library SafeManagerLib {
     (address[] memory modulesWith1,) = _safe.getModulesPaginated(SENTINELS, 1);
 
     return (modulesWith1.length == 0);
-
-    // QUESTION: do we need to bring back the valid signer count <= maxSigners check?
-    // return (modulesWith1.length == 0 && _countValidSigners(_safe.getOwners()) <= maxSigners);
   }
 
   /// @notice Internal function to find the previous owner of an `_owner` in an array of `_owners`, ie the pointer to

--- a/test/TestSuite.t.sol
+++ b/test/TestSuite.t.sol
@@ -237,7 +237,6 @@ contract TestSuite is SafeTestHelpers {
   // Test params
   uint256 public minThreshold;
   uint256 public targetThreshold;
-  uint256 public maxSigners;
   bool public locked;
   string public version;
 
@@ -287,7 +286,6 @@ contract TestSuite is SafeTestHelpers {
     // Set default test HSG params
     minThreshold = 2;
     targetThreshold = 2;
-    maxSigners = 5;
   }
 
   /*//////////////////////////////////////////////////////////////
@@ -317,7 +315,6 @@ contract TestSuite is SafeTestHelpers {
     uint256[] memory _signerHats,
     uint256 _minThreshold,
     uint256 _targetThreshold,
-    uint256 _maxSigners,
     address _safe,
     bool _locked,
     bool _claimableFor,
@@ -333,7 +330,6 @@ contract TestSuite is SafeTestHelpers {
       _signerHats,
       _minThreshold,
       _targetThreshold,
-      _maxSigners,
       _safe,
       _locked,
       _claimableFor,
@@ -353,7 +349,6 @@ contract TestSuite is SafeTestHelpers {
     uint256[] memory _signerHats,
     uint256 _minThreshold,
     uint256 _targetThreshold,
-    uint256 _maxSigners,
     bool _locked,
     bool _verbose,
     bool _claimableFor
@@ -367,7 +362,6 @@ contract TestSuite is SafeTestHelpers {
       _signerHats,
       _minThreshold,
       _targetThreshold,
-      _maxSigners,
       address(0),
       _locked,
       _claimableFor,
@@ -430,7 +424,6 @@ contract WithHSGInstanceTest is TestSuite {
       _signerHats: signerHats,
       _minThreshold: minThreshold,
       _targetThreshold: targetThreshold,
-      _maxSigners: maxSigners,
       _locked: false,
       _claimableFor: false,
       _verbose: false


### PR DESCRIPTION
This PR fully removes the `maxSigners` param.

It was originally added to v1 as an extra protection to ensure that not too many signers were added in case something went wrong with the `maxSupply` of the signer hat. But after 2 years of hats usage there haven't been any issues with `maxSupply` (neither contract bugs or user accidents), so I don't think the extra protection is needed.

That was for *single* HSG. For *multi* HSG — where multiple hats are valid signer hats — things are a touch different, since obviously we can't rely on the `maxSupply` of a single hat in that scenario. But even then, I don't think we need it. In practice, usage of MHSG has not been with high-supply hats where there is a race among hat-wearers to become signers on the safe. And this makes sense: why would anybody design a system of multiple hats where such a race would be required? Better to define the `maxSupply` of the relevant hats such that the number of signers on the multisig is always reasonable.

One challenge that `maxSigners` creates is that it forces us to do extra work to replace an invalid signer who is nonetheless taking up one of the signer slots. This challenge is especially annoying if we want to enable multiple signers to be added at once, since we have to keep track of them and the progress towards the maxSigners limit as we add each signer. 
- Why would we want to add multiple signers at once? Related to migrating/upgrading a Safe from one instance of HSG to another. 
- Why might we want to migrate? To use a new version or to remove signer hats.
- Why does migrating require adding multiple signers at once? To not force existing signers to re-claim after migration, ie to claimFor the signers as part of migration.