### PR TITLE
Misc cleanup

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -7,7 +7,7 @@ optimizer_runs = 1_000_000
 bytecode_hash = "none"
 gas_reports = ["*"]
 auto_detect_solc = false
-solc = "0.8.20"
+solc = "0.8.26"
 fs_permissions = [{ access = "read", path = "./"}]
 remappings = [
   "solmate/=lib/solmate/src/",

--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -228,9 +228,7 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
       }
 
       // execute the call
-      bool success = safe.execTransactionFromHSG(addOwnerData);
-
-      if (!success) revert SafeManagerLib.FailedExecAddSigner();
+      if (!safe.execTransactionFromHSG(addOwnerData)) revert SafeManagerLib.FailedExecAddSigner();
     }
   }
 
@@ -637,9 +635,7 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
     }
 
     // execute the call
-    bool success = safe.execTransactionFromHSG(addOwnerData);
-
-    if (!success) revert SafeManagerLib.FailedExecAddSigner();
+    if (!safe.execTransactionFromHSG(addOwnerData)) revert SafeManagerLib.FailedExecAddSigner();
   }
 
   /// @dev Internal function to remove a signer from the `safe`, updating the threshold if appropriate
@@ -667,9 +663,8 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
         SafeManagerLib.encodeRemoveOwnerAction(SafeManagerLib.findPrevOwner(owners, _signer), _signer, newThreshold);
     }
 
-    bool success = safe.execTransactionFromHSG(removeOwnerData);
-
-    if (!success) revert SafeManagerLib.FailedExecRemoveSigner();
+    // execute the call
+    if (!safe.execTransactionFromHSG(removeOwnerData)) revert SafeManagerLib.FailedExecRemoveSigner();
   }
 
   // solhint-disallow-next-line payable-fallback

--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.13;
 // import { Test, console2 } from "forge-std/Test.sol"; // comment out after testing
 import { IHats } from "../lib/hats-protocol/src/Interfaces/IHats.sol";
 import { SafeManagerLib } from "./lib/SafeManagerLib.sol";
-import { IHatsSignerGate, HSGEvents } from "./interfaces/IHatsSignerGate.sol";
+import { IHatsSignerGate } from "./interfaces/IHatsSignerGate.sol";
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { BaseGuard } from "lib/zodiac/contracts/guard/BaseGuard.sol";
 import { SignatureDecoder } from "lib/safe-smart-account/contracts/common/SignatureDecoder.sol";
@@ -329,7 +329,7 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
     // first remove as guard, then as module
     s.execRemoveHSGAsGuard();
     s.execDisableHSGAsOnlyModule();
-    emit HSGEvents.Detached();
+    emit Detached();
   }
 
   /// @notice Migrate the Safe to a new HSG, ie detach this HSG and attach a new HSG
@@ -345,7 +345,7 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
     s.execAttachNewHSG(_newHSG);
     // remove existing HSG as module
     s.execDisableHSGAsModule(_newHSG);
-    emit HSGEvents.Migrated(_newHSG);
+    emit Migrated(_newHSG);
   }
 
   /*//////////////////////////////////////////////////////////////
@@ -546,7 +546,7 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
   /// @param _ownerHat The hat id to set as the owner hat
   function _setOwnerHat(uint256 _ownerHat) internal {
     ownerHat = _ownerHat;
-    emit HSGEvents.OwnerHatUpdated(_ownerHat);
+    emit OwnerHatUpdated(_ownerHat);
   }
 
   // /// @notice Checks if `_account` is a valid signer
@@ -567,7 +567,7 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
       }
     }
 
-    emit HSGEvents.SignerHatsAdded(_newSignerHats);
+    emit SignerHatsAdded(_newSignerHats);
   }
 
   /// @notice Internal function to set the target threshold
@@ -578,7 +578,7 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
     if (_targetThreshold < minThreshold) revert InvalidTargetThreshold();
 
     targetThreshold = _targetThreshold;
-    emit HSGEvents.TargetThresholdSet(_targetThreshold);
+    emit TargetThresholdSet(_targetThreshold);
   }
 
   /// @notice Internal function to set the threshold for the `safe`
@@ -604,7 +604,7 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
     if (_minThreshold > targetThreshold) revert InvalidMinThreshold();
 
     minThreshold = _minThreshold;
-    emit HSGEvents.MinThresholdSet(_minThreshold);
+    emit MinThresholdSet(_minThreshold);
   }
 
   /// @notice Internal function to count the number of valid signers in an array of addresses
@@ -631,7 +631,7 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
   /// @param _claimableFor Whether signer permissions are claimable on behalf of valid hat wearers
   function _setClaimableFor(bool _claimableFor) internal {
     claimableFor = _claimableFor;
-    emit HSGEvents.ClaimableForSet(_claimableFor);
+    emit ClaimableForSet(_claimableFor);
   }
 
   /// @notice Internal function to add a `_signer` to the `safe` if they are wearing a valid signer hat.
@@ -741,6 +741,6 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
   /// @dev Locks the contract, preventing any further owner changes
   function _lock() internal {
     locked = true;
-    emit HSGEvents.Locked();
+    emit HSGLocked();
   }
 }

--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -22,44 +22,53 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
                             CONSTANTS
   //////////////////////////////////////////////////////////////*/
 
+  /// @inheritdoc IHatsSignerGate
   IHats public immutable HATS;
+
+  /// @inheritdoc IHatsSignerGate
   address public immutable safeSingleton;
+
+  /// @inheritdoc IHatsSignerGate
   address public immutable safeFallbackLibrary;
+
+  /// @inheritdoc IHatsSignerGate
   address public immutable safeMultisendLibrary;
+
+  /// @inheritdoc IHatsSignerGate
   address public immutable safeProxyFactory;
 
   /*//////////////////////////////////////////////////////////////
                             MUTABLE STATE
   //////////////////////////////////////////////////////////////*/
 
-  /// @notice Append-only tracker of approved signer hats
+  /// @inheritdoc IHatsSignerGate
   mapping(uint256 => bool) public validSignerHats;
 
-  /// @notice Tracks the hat ids worn by users who have "claimed signer"
+  /// @inheritdoc IHatsSignerGate
   mapping(address => uint256) public claimedSignerHats;
 
-  /// @notice The id of the owner hat
+  /// @inheritdoc IHatsSignerGate
   uint256 public ownerHat;
 
-  /// @notice The multisig to which this contract is attached
+  /// @inheritdoc IHatsSignerGate
   ISafe public safe;
 
-  /// @notice The minimum signature threshold for the `safe`
+  /// @inheritdoc IHatsSignerGate
   uint256 public minThreshold;
 
-  /// @notice The highest level signature threshold for the `safe`
+  /// @inheritdoc IHatsSignerGate
   uint256 public targetThreshold;
 
-  /// @notice Whether the contract is locked. If true, the owner cannot change any of the contract's settings.
+  /// @inheritdoc IHatsSignerGate
   bool public locked;
 
-  /// @notice Whether signer permissions can be claimed on behalf of valid hat wearers
+  /// @inheritdoc IHatsSignerGate
   bool public claimableFor;
 
-  /// @notice The implementation address of this contract
+  /// @inheritdoc IHatsSignerGate
   address public implementation;
 
-  /// @notice The version of HatsSignerGate used in this contract
+  /// @inheritdoc IHatsSignerGate
   string public version;
 
   /// @dev Temporary record of the existing owners on the `safe` when a transaction is submitted
@@ -113,13 +122,7 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
                               INITIALIZER
   //////////////////////////////////////////////////////////////*/
 
-  /**
-   * @notice Initializes a new instance of HatsSignerGate.
-   *  Does NOT check if the target Safe is compatible with this HSG.
-   * @dev Can only be called once
-   * @param initializeParams ABI-encoded bytes with initialization parameters, as defined in
-   * {IHatsSignerGate.SetupParams}
-   */
+  /// @inheritdoc IHatsSignerGate
   function setUp(bytes calldata initializeParams) public payable initializer {
     SetupParams memory params = abi.decode(initializeParams, (SetupParams));
 
@@ -154,15 +157,12 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
                           PUBLIC FUNCTIONS
   //////////////////////////////////////////////////////////////*/
 
-  /// @notice Function to become an owner on the safe if you are wearing `_hatId` and `_hatId` is a valid signer hat
-  /// @dev Reverts if the caller is either invalid or has already claimed.
-  /// @param _hatId The hat id to claim signer rights for
+  /// @inheritdoc IHatsSignerGate
   function claimSigner(uint256 _hatId) public {
     _addSigner(_hatId, msg.sender);
   }
 
-  /// @notice Claims signer permissions for a valid wearer of `_hatId` on behalf of `_signer`
-  /// @param _hatId The hat id to claim signer rights for
+  /// @inheritdoc IHatsSignerGate
   function claimSignerFor(uint256 _hatId, address _signer) public {
     // check that signer permissions are claimable for
     if (!claimableFor) revert NotClaimableFor();
@@ -170,11 +170,7 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
     _addSigner(_hatId, _signer);
   }
 
-  /// @notice Claims signer permissions for a set of valid wearers of `_hatIds` on behalf of the `_signers`
-  /// If this contract is the only owner on the `safe`, it will be swapped out for the first `_signer`. Otherwise, each
-  /// `_signer` will be added as a new owner.
-  /// @param _hatIds The hat ids to use for adding each of the `_signers`, indexed to `_signers`
-  /// @param _signers The addresses to add as new `safe` owners, indexed to `_hatIds`
+  /// @inheritdoc IHatsSignerGate
   function claimSignersFor(uint256[] calldata _hatIds, address[] calldata _signers) public {
     // check that signer permissions are claimable for
     if (!claimableFor) revert NotClaimableFor();
@@ -242,17 +238,14 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
     }
   }
 
-  /// @notice Removes an invalid signer from the `safe`, updating the threshold if appropriate
-  /// @param _signer The address to remove if not a valid signer
+  /// @inheritdoc IHatsSignerGate
   function removeSigner(address _signer) public virtual {
     if (isValidSigner(_signer)) revert StillWearsSignerHat(_signer);
 
     _removeSigner(_signer);
   }
 
-  /// @notice Tallies the number of existing `safe` owners that wear a signer hat and updates the `safe` threshold if
-  /// necessary
-  /// @dev Does NOT remove invalid `safe` owners
+  /// @inheritdoc IHatsSignerGate
   function reconcileSignerCount() public {
     uint256 signerCount = validSignerCount();
 
@@ -274,29 +267,22 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
                         OWNER FUNCTIONS
   //////////////////////////////////////////////////////////////*/
 
-  /// @notice Irreversibly locks the contract, preventing any further changes to the contract's settings.
-  /// @dev Only callable by a wearer of the owner hat, and only if the contract is not locked.
+  /// @inheritdoc IHatsSignerGate
   function lock() public onlyOwner onlyUnlocked {
     _lock();
   }
 
-  /// @notice Sets the owner hat
-  /// @dev Only callable by a wearer of the current owner hat, and only if the contract is not locked
-  /// @param _ownerHat The new owner hat
+  /// @inheritdoc IHatsSignerGate
   function setOwnerHat(uint256 _ownerHat) public onlyOwner onlyUnlocked {
     _setOwnerHat(_ownerHat);
   }
 
-  /// @notice Adds new approved signer hats
-  /// @dev Only callable by a wearer of the owner hat, and only if the contract is not locked.
-  /// @param _newSignerHats Array of hat ids to add as approved signer hats
+  /// @inheritdoc IHatsSignerGate
   function addSignerHats(uint256[] calldata _newSignerHats) external onlyOwner onlyUnlocked {
     _addSignerHats(_newSignerHats);
   }
 
-  /// @notice Sets a new target threshold, and changes `safe`'s threshold if appropriate
-  /// @dev Only callable by a wearer of the owner hat, and only if the contract is not locked.
-  /// @param _targetThreshold The new target threshold to set
+  /// @inheritdoc IHatsSignerGate
   function setTargetThreshold(uint256 _targetThreshold) public onlyOwner onlyUnlocked {
     if (_targetThreshold != targetThreshold) {
       _setTargetThreshold(_targetThreshold);
@@ -306,23 +292,17 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
     }
   }
 
-  /// @notice Sets a new minimum threshold
-  /// @dev Only callable by a wearer of the owner hat, and only if the contract is not locked.
-  /// Reverts if `_minThreshold` is greater than `targetThreshold`
-  /// @param _minThreshold The new minimum threshold
+  /// @inheritdoc IHatsSignerGate
   function setMinThreshold(uint256 _minThreshold) public onlyOwner onlyUnlocked {
     _setMinThreshold(_minThreshold);
   }
 
-  /// @notice Sets whether signer permissions can be claimed on behalf of valid hat wearers
-  /// @dev Only callable by a wearer of the owner hat, and only if the contract is not locked.
-  /// @param _claimableFor Whether signer permissions can be claimed on behalf of valid hat wearers
+  /// @inheritdoc IHatsSignerGate
   function setClaimableFor(bool _claimableFor) public onlyOwner onlyUnlocked {
     _setClaimableFor(_claimableFor);
   }
 
-  /// @notice Detach HSG from the Safe
-  /// @dev Only callable by a wearer of the owner hat, and only if the contract is not locked.
+  /// @inheritdoc IHatsSignerGate
   function detachHSG() public onlyOwner onlyUnlocked {
     ISafe s = safe; // save SLOAD
 
@@ -332,9 +312,7 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
     emit Detached();
   }
 
-  /// @notice Migrate the Safe to a new HSG, ie detach this HSG and attach a new HSG
-  /// @dev Only callable by a wearer of the owner hat, and only if the contract is not locked.
-  /// @param _newHSG The new HatsSignerGate to attach to the Safe
+  /// @inheritdoc IHatsSignerGate
   function migrateToNewHSG(address _newHSG) public onlyOwner onlyUnlocked {
     // QUESTION check if _newHSG is indeed an HSG?
 
@@ -352,9 +330,7 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
                       ZODIAC GUARD FUNCTIONS
   //////////////////////////////////////////////////////////////*/
 
-  /// @notice Pre-flight check on a `safe` transaction to ensure that it s signers are valid, called from within
-  /// `safe.execTransactionFromModule()`
-  /// @dev Overrides All params mirror params for `safe.execTransactionFromModule()`
+  /// @inheritdoc BaseGuard
   function checkTransaction(
     address to,
     uint256 value,
@@ -457,41 +433,28 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
                           VIEW FUNCTIONS
   //////////////////////////////////////////////////////////////*/
 
-  /// @notice Checks if `_account` is a valid signer, ie is wearing the signer hat
-  /// @dev Must be implemented by all flavors of HatsSignerGate
-  /// @param _account The address to check
-  /// @return valid Whether `_account` is a valid signer
+  /// @inheritdoc IHatsSignerGate
   function isValidSigner(address _account) public view returns (bool valid) {
     /// @dev existing `claimedSignerHats` are always valid, since `validSignerHats` is append-only
     valid = HATS.isWearerOfHat(_account, claimedSignerHats[_account]);
   }
 
-  /// @notice A `_hatId` is valid if it is included in the `validSignerHats` mapping
-  /// @param _hatId The hat id to check
-  /// @return valid Whether `_hatId` is a valid signer hat
+  /// @inheritdoc IHatsSignerGate
   function isValidSignerHat(uint256 _hatId) public view returns (bool valid) {
     valid = validSignerHats[_hatId];
   }
 
-  /// @notice Tallies the number of existing `safe` owners that wear a signer hat
-  /// @return signerCount The number of valid signers on the `safe`
+  /// @inheritdoc IHatsSignerGate
   function validSignerCount() public view returns (uint256 signerCount) {
     signerCount = _countValidSigners(safe.getOwners());
   }
 
-  /**
-   * @notice Checks if a HatsSignerGate can be safely attached to a Safe, ie there must be no existing modules
-   */
+  /// @inheritdoc IHatsSignerGate
   function canAttachToSafe() public view returns (bool) {
     return safe.canAttachHSG();
   }
 
-  /// @notice Counts the number of hats-valid signatures within a set of `signatures`
-  /// @dev modified from
-  /// https://github.com/safe-global/safe-contracts/blob/c36bcab46578a442862d043e12a83fec41143dec/contracts/Safe.sol#L240
-  /// @param dataHash The signed data
-  /// @param signatures The set of signatures to check
-  /// @return validSigCount The number of hats-valid signatures
+  /// @inheritdoc IHatsSignerGate
   function countValidSignatures(bytes32 dataHash, bytes memory signatures, uint256 sigCount)
     public
     view
@@ -555,7 +518,7 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
   // /// @return valid Whether `_account` is a valid signer
   // function isValidSigner(address _account) public view virtual returns (bool valid) { }
 
-  /// @notice Internal function to approve new signer hats
+  /// @dev Internal function to approve new signer hats
   /// @param _newSignerHats Array of hat ids to add as approved signer hats
   function _addSignerHats(uint256[] memory _newSignerHats) internal {
     for (uint256 i = 0; i < _newSignerHats.length;) {
@@ -570,8 +533,7 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
     emit SignerHatsAdded(_newSignerHats);
   }
 
-  /// @notice Internal function to set the target threshold
-  /// @dev Reverts if `_targetThreshold` is lower than `minThreshold`
+  /// @dev Internal function to set the target threshold. Reverts if `_targetThreshold` is lower than `minThreshold`
   /// @param _targetThreshold The new target threshold to set
   function _setTargetThreshold(uint256 _targetThreshold) internal {
     // target threshold cannot be lower than min threshold
@@ -581,8 +543,7 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
     emit TargetThresholdSet(_targetThreshold);
   }
 
-  /// @notice Internal function to set the threshold for the `safe`
-  /// @dev Forwards the threshold-setting call to `SafeManagerLib.execChangeThreshold`
+  /// @dev Internal function to set the threshold for the `safe`
   /// @param _threshold The threshold to set on the `safe`
   /// @param _signerCount The number of valid signers on the `safe`; should be calculated from `validSignerCount()`
   function _setSafeThreshold(uint256 _threshold, uint256 _signerCount) internal {
@@ -597,8 +558,8 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
     }
   }
 
-  /// @notice Internal function to set a new minimum threshold
-  /// @dev Only callable by a wearer of the owner hat. Reverts if `_minThreshold` is greater than `targetThreshold`
+  /// @dev Internal function to set a new minimum threshold. Only callable by a wearer of the owner hat.
+  /// Reverts if `_minThreshold` is greater than `targetThreshold`
   /// @param _minThreshold The new minimum threshold
   function _setMinThreshold(uint256 _minThreshold) internal {
     if (_minThreshold > targetThreshold) revert InvalidMinThreshold();
@@ -607,7 +568,7 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
     emit MinThresholdSet(_minThreshold);
   }
 
-  /// @notice Internal function to count the number of valid signers in an array of addresses
+  /// @dev Internal function to count the number of valid signers in an array of addresses
   /// @param owners The addresses to check for validity
   /// @return signerCount The number of valid signers in `owners`
   function _countValidSigners(address[] memory owners) internal view returns (uint256 signerCount) {
@@ -627,14 +588,14 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
     }
   }
 
-  /// @notice Internal function to set the claimableFor parameter
+  /// @dev Internal function to set the claimableFor parameter
   /// @param _claimableFor Whether signer permissions are claimable on behalf of valid hat wearers
   function _setClaimableFor(bool _claimableFor) internal {
     claimableFor = _claimableFor;
     emit ClaimableForSet(_claimableFor);
   }
 
-  /// @notice Internal function to add a `_signer` to the `safe` if they are wearing a valid signer hat.
+  /// @dev Internal function to add a `_signer` to the `safe` if they are wearing a valid signer hat.
   /// If this contract is the only owner on the `safe`, it will be swapped out for `_signer`. Otherwise, `_signer` will
   /// be added as a new owner.
   /// @param _hatId The hat id to use for the claim
@@ -690,8 +651,8 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
     if (!success) revert SafeManagerLib.FailedExecAddSigner();
   }
 
-  /// @notice Internal function to remove a signer from the `safe`, updating the threshold if appropriate
-  /// @dev Unsafe. Does not check for signer validity before removal
+  /// @dev Internal function to remove a signer from the `safe`, updating the threshold if appropriate
+  /// Unsafe. Does not check for signer validity before removal
   /// @param _signer The address to remove
   function _removeSigner(address _signer) internal {
     bytes memory removeOwnerData;
@@ -726,7 +687,7 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
     // E.g. The expected check method might change and then the Safe would be locked.
   }
 
-  /// @notice Internal function to calculate the threshold that `safe` should have, given the correct `signerCount`,
+  /// @dev Internal function to calculate the threshold that `safe` should have, given the correct `signerCount`,
   /// `minThreshold`, and `targetThreshold`
   /// @return _threshold The correct threshold
   function _getCorrectThreshold() internal view returns (uint256 _threshold) {

--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -180,7 +180,7 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
     if (_hatIds.length != toClaimCount) revert InvalidArrayLength();
 
     // iterate through the arrays, adding each signer
-    for (uint256 i; i < toClaimCount;) {
+    for (uint256 i; i < toClaimCount; ++i) {
       uint256 hatId = _hatIds[i];
       address signer = _signers[i];
 
@@ -231,10 +231,6 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
       bool success = safe.execTransactionFromHSG(addOwnerData);
 
       if (!success) revert SafeManagerLib.FailedExecAddSigner();
-
-      unchecked {
-        ++i;
-      }
     }
   }
 
@@ -380,8 +376,10 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
     if (validSigCount < threshold || validSigCount < minThreshold) revert InvalidSigners();
 
     // record existing owners for post-flight check
+    // TODO use TSTORE
     _existingOwnersHash = keccak256(abi.encode(owners));
 
+    // TODO use TSTORE
     unchecked {
       ++_guardEntries;
     }
@@ -467,7 +465,7 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
     bytes32 s;
     uint256 i;
 
-    for (i; i < sigCount;) {
+    for (i; i < sigCount; ++i) {
       (v, r, s) = signatureSplit(signatures, i);
       if (v == 0) {
         // If v is 0 then it is a contract signature
@@ -494,10 +492,6 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
           ++validSigCount;
         }
       }
-      // shouldn't overflow given reasonable sigCount
-      unchecked {
-        ++i;
-      }
     }
   }
 
@@ -521,13 +515,8 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
   /// @dev Internal function to approve new signer hats
   /// @param _newSignerHats Array of hat ids to add as approved signer hats
   function _addSignerHats(uint256[] memory _newSignerHats) internal {
-    for (uint256 i = 0; i < _newSignerHats.length;) {
+    for (uint256 i; i < _newSignerHats.length; ++i) {
       validSignerHats[_newSignerHats[i]] = true;
-
-      // should not overflow with feasible array length
-      unchecked {
-        ++i;
-      }
     }
 
     emit SignerHatsAdded(_newSignerHats);
@@ -574,16 +563,12 @@ contract HatsSignerGate is IHatsSignerGate, BaseGuard, SignatureDecoder, Initial
   function _countValidSigners(address[] memory owners) internal view returns (uint256 signerCount) {
     uint256 length = owners.length;
     // count the existing safe owners that wear the signer hat
-    for (uint256 i; i < length;) {
+    for (uint256 i; i < length; ++i) {
       if (isValidSigner(owners[i])) {
         // shouldn't overflow given reasonable owners array length
         unchecked {
           ++signerCount;
         }
-      }
-      // shouldn't overflow given reasonable owners array length
-      unchecked {
-        ++i;
       }
     }
   }

--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
-// import { Test, console2 } from "forge-std/Test.sol"; // comment out after testing
+// import { Test, console2 } from "../lib/forge-std/src/Test.sol"; // comment out after testing
 import { IHats } from "../lib/hats-protocol/src/Interfaces/IHats.sol";
 import { SafeManagerLib } from "./lib/SafeManagerLib.sol";
 import { IHatsSignerGate } from "./interfaces/IHatsSignerGate.sol";
-import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import { BaseGuard } from "lib/zodiac/contracts/guard/BaseGuard.sol";
-import { SignatureDecoder } from "lib/safe-smart-account/contracts/common/SignatureDecoder.sol";
+import { Initializable } from "../lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
+import { BaseGuard } from "../lib/zodiac/contracts/guard/BaseGuard.sol";
+import { SignatureDecoder } from "../lib/safe-smart-account/contracts/common/SignatureDecoder.sol";
 import { ISafe, Enum } from "./lib/safe-interfaces/ISafe.sol";
 
 /// @title HatsSignerGate

--- a/src/interfaces/IHatsSignerGate.sol
+++ b/src/interfaces/IHatsSignerGate.sol
@@ -3,33 +3,6 @@ pragma solidity >=0.8.13;
 
 import { Enum, ISafe } from "../lib/safe-interfaces/ISafe.sol";
 
-/// @notice Events emitted by the HatsSignerGate contract
-library HSGEvents {
-  /// @notice Emitted when a new target signature threshold for the `safe` is set
-  event TargetThresholdSet(uint256 threshold);
-
-  /// @notice Emitted when a new minimum signature threshold for the `safe` is set
-  event MinThresholdSet(uint256 threshold);
-
-  /// @notice Emitted when new approved signer hats are added
-  event SignerHatsAdded(uint256[] newSignerHats);
-
-  /// @notice Emitted when the owner hat is updated
-  event OwnerHatUpdated(uint256 ownerHat);
-
-  /// @notice Emitted when the contract is locked, preventing any further changes to settings
-  event Locked();
-
-  /// @notice Emitted when the claimableFor parameter is set
-  event ClaimableForSet(bool claimableFor);
-
-  /// @notice Emitted when HSG has been detached from its avatar Safe
-  event Detached();
-
-  /// @notice Emitted when HSG has been migrated to a new HSG
-  event Migrated(address newHSG);
-}
-
 /// @notice Interface for the HatsSignerGate contract
 interface IHatsSignerGate {
   /*//////////////////////////////////////////////////////////////
@@ -118,6 +91,34 @@ interface IHatsSignerGate {
 
   /// @notice The input arrays must be the same length
   error InvalidArrayLength();
+
+  /*//////////////////////////////////////////////////////////////
+                              EVENTS
+  //////////////////////////////////////////////////////////////*/
+
+  /// @notice Emitted when a new target signature threshold for the `safe` is set
+  event TargetThresholdSet(uint256 threshold);
+
+  /// @notice Emitted when a new minimum signature threshold for the `safe` is set
+  event MinThresholdSet(uint256 threshold);
+
+  /// @notice Emitted when new approved signer hats are added
+  event SignerHatsAdded(uint256[] newSignerHats);
+
+  /// @notice Emitted when the owner hat is updated
+  event OwnerHatUpdated(uint256 ownerHat);
+
+  /// @notice Emitted when the contract is locked, preventing any further changes to settings
+  event HSGLocked();
+
+  /// @notice Emitted when the claimableFor parameter is set
+  event ClaimableForSet(bool claimableFor);
+
+  /// @notice Emitted when HSG has been detached from its avatar Safe
+  event Detached();
+
+  /// @notice Emitted when HSG has been migrated to a new HSG
+  event Migrated(address newHSG);
 
   /*//////////////////////////////////////////////////////////////
                               FUNCTIONS

--- a/src/lib/SafeManagerLib.sol
+++ b/src/lib/SafeManagerLib.sol
@@ -261,14 +261,10 @@ library SafeManagerLib {
   function findPrevOwner(address[] memory _owners, address _owner) internal pure returns (address prevOwner) {
     prevOwner = SENTINELS;
 
-    for (uint256 i; i < _owners.length;) {
+    for (uint256 i; i < _owners.length; ++i) {
       if (_owners[i] == _owner) {
         if (i == 0) break;
         prevOwner = _owners[i - 1];
-      }
-      // shouldn't overflow given reasonable _owners array length
-      unchecked {
-        ++i;
       }
     }
   }

--- a/src/lib/SafeManagerLib.sol
+++ b/src/lib/SafeManagerLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
-// import { console2 } from "forge-std/console2.sol";
+// import { console2 } from "../lib/forge-std/src/console2.sol";
 import { MultiSend } from "../../lib/safe-smart-account/contracts/libraries/MultiSend.sol";
 import { SafeProxyFactory } from "../../lib/safe-smart-account/contracts/proxies/SafeProxyFactory.sol";
 import { StorageAccessible } from "../../lib/safe-smart-account/contracts/common/StorageAccessible.sol";

--- a/src/lib/SafeManagerLib.sol
+++ b/src/lib/SafeManagerLib.sol
@@ -183,9 +183,8 @@ library SafeManagerLib {
     // Generate calldata to remove HSG as a module
     bytes memory removeHSGModule = encodeDisableModuleAction(SENTINELS, address(this));
 
-    bool success = execTransactionFromHSG(_safe, removeHSGModule);
-
-    if (!success) revert FailedExecChangeThreshold();
+    // execute the call
+    if (!execTransactionFromHSG(_safe, removeHSGModule)) revert FailedExecChangeThreshold();
   }
 
   /// @dev Encode the action to disable HSG as a module on a `_safe`
@@ -211,17 +210,6 @@ library SafeManagerLib {
 
     execTransactionFromHSG(_safe, setHSGGuard);
     execTransactionFromHSG(_safe, attachHSGModule);
-  }
-
-  /// @dev Execute the action to swap the owner of a `_safe` from `_oldOwner` to `_newOwner`
-  /// @param _prevOwner The previous owner in the owners linked list
-  function execSwapOwner(ISafe _safe, address _prevOwner, address _oldOwner, address _newOwner)
-    internal
-    returns (bool success)
-  {
-    success = execTransactionFromHSG(_safe, encodeSwapOwnerAction(_prevOwner, _oldOwner, _newOwner));
-
-    if (!success) revert FailedExecRemoveSigner();
   }
 
   /// @dev Execute the action to change the threshold of a `_safe` to `_newThreshold`

--- a/src/lib/SafeManagerLib.sol
+++ b/src/lib/SafeManagerLib.sol
@@ -15,6 +15,7 @@ library SafeManagerLib {
   /*//////////////////////////////////////////////////////////////
                               CUSTOM ERRORS
   //////////////////////////////////////////////////////////////*/
+
   /// @notice Emitted when a call to change the threshold fails
   error FailedExecChangeThreshold();
 
@@ -30,6 +31,7 @@ library SafeManagerLib {
   /*//////////////////////////////////////////////////////////////
                               CONSTANTS
   //////////////////////////////////////////////////////////////*/
+
   /// @dev The head pointer used in the Safe owners linked list, as well as the module linked list
   address internal constant SENTINELS = address(0x1);
 

--- a/test/HatsSignerGate.attacks.t.sol
+++ b/test/HatsSignerGate.attacks.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import { Test, console2 } from "forge-std/Test.sol";
+import { Test, console2 } from "../lib/forge-std/src/Test.sol";
 import { WithHSGInstanceTest, Enum } from "./TestSuite.t.sol";
 import { IHatsSignerGate } from "../src/interfaces/IHatsSignerGate.sol";
 

--- a/test/HatsSignerGate.t.sol
+++ b/test/HatsSignerGate.t.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.13;
 
 import { Test, console2 } from "forge-std/Test.sol";
-import { Enum, ISafe, ModuleProxyFactory, TestSuite, WithHSGInstanceTest, HatsSignerGate } from "./TestSuite.t.sol";
-import { IHatsSignerGate, HSGEvents } from "../src/interfaces/IHatsSignerGate.sol";
+import { Enum, ISafe, TestSuite, WithHSGInstanceTest, HatsSignerGate } from "./TestSuite.t.sol";
+import { IHatsSignerGate } from "../src/interfaces/IHatsSignerGate.sol";
 import { DeployInstance } from "../script/HatsSignerGate.s.sol";
 
 contract Deployment is TestSuite {
@@ -87,7 +87,7 @@ contract AddingSignerHats is WithHSGInstanceTest {
 
     vm.prank(owner);
     vm.expectEmit(false, false, false, true);
-    emit HSGEvents.SignerHatsAdded(hats);
+    emit IHatsSignerGate.SignerHatsAdded(hats);
 
     hatsSignerGate.addSignerHats(hats);
   }
@@ -128,7 +128,7 @@ contract SettingTargetThreshold is WithHSGInstanceTest {
 
     vm.prank(owner);
     vm.expectEmit(false, false, false, true);
-    emit HSGEvents.TargetThresholdSet(3);
+    emit IHatsSignerGate.TargetThresholdSet(3);
     hatsSignerGate.setTargetThreshold(3);
 
     assertEq(hatsSignerGate.targetThreshold(), 3);
@@ -140,7 +140,7 @@ contract SettingTargetThreshold is WithHSGInstanceTest {
 
     vm.prank(owner);
     vm.expectEmit(false, false, false, true);
-    emit HSGEvents.TargetThresholdSet(3);
+    emit IHatsSignerGate.TargetThresholdSet(3);
 
     hatsSignerGate.setTargetThreshold(3);
 
@@ -153,7 +153,7 @@ contract SettingTargetThreshold is WithHSGInstanceTest {
 
     vm.prank(owner);
     vm.expectEmit(false, false, false, true);
-    emit HSGEvents.TargetThresholdSet(4);
+    emit IHatsSignerGate.TargetThresholdSet(4);
 
     hatsSignerGate.setTargetThreshold(4);
 
@@ -186,7 +186,7 @@ contract SettingMinThreshold is WithHSGInstanceTest {
     hatsSignerGate.setTargetThreshold(3);
 
     vm.expectEmit(false, false, false, true);
-    emit HSGEvents.MinThresholdSet(3);
+    emit IHatsSignerGate.MinThresholdSet(3);
 
     vm.prank(owner);
     hatsSignerGate.setMinThreshold(3);
@@ -965,7 +965,7 @@ contract ReconcilingSignerCount is WithHSGInstanceTest {
 contract DetachingHSG is WithHSGInstanceTest {
   function test_happy() public {
     vm.expectEmit(true, true, true, true);
-    emit HSGEvents.Detached();
+    emit IHatsSignerGate.Detached();
     vm.prank(owner);
     hatsSignerGate.detachHSG();
 
@@ -1023,7 +1023,7 @@ contract MigratingHSG is WithHSGInstanceTest {
 
   function test_happy() public {
     vm.expectEmit(true, true, true, true);
-    emit HSGEvents.Migrated(address(newHSG));
+    emit IHatsSignerGate.Migrated(address(newHSG));
     vm.prank(owner);
     hatsSignerGate.migrateToNewHSG(address(newHSG));
 
@@ -1051,7 +1051,7 @@ contract MigratingHSG is WithHSGInstanceTest {
 contract SettingClaimableFor is WithHSGInstanceTest {
   function test_happy(bool _claimableFor) public {
     vm.expectEmit(true, true, true, true);
-    emit HSGEvents.ClaimableForSet(_claimableFor);
+    emit IHatsSignerGate.ClaimableForSet(_claimableFor);
     vm.prank(owner);
     hatsSignerGate.setClaimableFor(_claimableFor);
 

--- a/test/HatsSignerGate.t.sol
+++ b/test/HatsSignerGate.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import { Test, console2 } from "forge-std/Test.sol";
+import { Test, console2 } from "../lib/forge-std/src/Test.sol";
 import { Enum, ISafe, TestSuite, WithHSGInstanceTest, HatsSignerGate } from "./TestSuite.t.sol";
 import { IHatsSignerGate } from "../src/interfaces/IHatsSignerGate.sol";
 import { DeployInstance } from "../script/HatsSignerGate.s.sol";

--- a/test/HatsSignerGate.t.sol
+++ b/test/HatsSignerGate.t.sol
@@ -1160,7 +1160,7 @@ contract ClaimingSignersFor is WithHSGInstanceTest {
     _signerCount = bound(_signerCount, 1, signerAddresses.length);
 
     // set up signer validity
-    for (uint256 i; i < _signerCount; i++) {
+    for (uint256 i; i < _signerCount; ++i) {
       _setSignerValidity(signerAddresses[i], signerHat, true);
     }
 
@@ -1171,7 +1171,7 @@ contract ClaimingSignersFor is WithHSGInstanceTest {
     // create the necessary arrays
     address[] memory claimers = new address[](_signerCount);
     uint256[] memory hatIds = new uint256[](_signerCount);
-    for (uint256 i; i < _signerCount; i++) {
+    for (uint256 i; i < _signerCount; ++i) {
       claimers[i] = signerAddresses[i];
       hatIds[i] = signerHat;
     }
@@ -1187,7 +1187,7 @@ contract ClaimingSignersFor is WithHSGInstanceTest {
     _signerCount = bound(_signerCount, 1, signerAddresses.length);
 
     // set up signer validity
-    for (uint256 i; i < _signerCount; i++) {
+    for (uint256 i; i < _signerCount; ++i) {
       _setSignerValidity(signerAddresses[i], signerHat, true);
     }
 
@@ -1203,7 +1203,7 @@ contract ClaimingSignersFor is WithHSGInstanceTest {
     // create the necessary arrays, starting with the next signer
     address[] memory claimers = new address[](_signerCount - 1);
     uint256[] memory hatIds = new uint256[](_signerCount - 1);
-    for (uint256 i; i < _signerCount - 1; i++) {
+    for (uint256 i; i < _signerCount - 1; ++i) {
       claimers[i] = signerAddresses[i + 1];
       hatIds[i] = signerHat;
     }
@@ -1219,7 +1219,7 @@ contract ClaimingSignersFor is WithHSGInstanceTest {
     _signerCount = bound(_signerCount, 1, signerAddresses.length);
 
     // set up signer validity
-    for (uint256 i; i < _signerCount; i++) {
+    for (uint256 i; i < _signerCount; ++i) {
       _setSignerValidity(signerAddresses[i], signerHat, true);
     }
 
@@ -1232,7 +1232,7 @@ contract ClaimingSignersFor is WithHSGInstanceTest {
     // create the necessary arrays
     address[] memory claimers = new address[](_signerCount);
     uint256[] memory hatIds = new uint256[](_signerCount);
-    for (uint256 i; i < _signerCount; i++) {
+    for (uint256 i; i < _signerCount; ++i) {
       claimers[i] = signerAddresses[i];
       hatIds[i] = signerHat;
     }
@@ -1249,7 +1249,7 @@ contract ClaimingSignersFor is WithHSGInstanceTest {
     uint256 invalidSignerHat = signerHat + 1;
 
     // set up signer validity
-    for (uint256 i; i < _signerCount; i++) {
+    for (uint256 i; i < _signerCount; ++i) {
       _setSignerValidity(signerAddresses[i], signerHat, true);
     }
 
@@ -1260,7 +1260,7 @@ contract ClaimingSignersFor is WithHSGInstanceTest {
     // create the necessary arrays
     address[] memory claimers = new address[](_signerCount);
     uint256[] memory hatIds = new uint256[](_signerCount);
-    for (uint256 i; i < _signerCount; i++) {
+    for (uint256 i; i < _signerCount; ++i) {
       claimers[i] = signerAddresses[i];
       hatIds[i] = invalidSignerHat;
     }
@@ -1274,7 +1274,7 @@ contract ClaimingSignersFor is WithHSGInstanceTest {
     _invalidSignerIndex = bound(_invalidSignerIndex, 0, _signerCount - 1);
 
     // set up signer validity
-    for (uint256 i; i < _signerCount; i++) {
+    for (uint256 i; i < _signerCount; ++i) {
       if (i == _invalidSignerIndex) {
         _setSignerValidity(signerAddresses[i], signerHat, false);
       } else {
@@ -1289,7 +1289,7 @@ contract ClaimingSignersFor is WithHSGInstanceTest {
     // create the necessary arrays
     address[] memory claimers = new address[](_signerCount);
     uint256[] memory hatIds = new uint256[](_signerCount);
-    for (uint256 i; i < _signerCount; i++) {
+    for (uint256 i; i < _signerCount; ++i) {
       claimers[i] = signerAddresses[i];
       hatIds[i] = signerHat;
     }
@@ -1305,7 +1305,7 @@ contract ClaimingSignersFor is WithHSGInstanceTest {
     _alreadyClaimedIndex = bound(_alreadyClaimedIndex, 0, _signerCount - 1);
 
     // set up signer validity
-    for (uint256 i; i < _signerCount; i++) {
+    for (uint256 i; i < _signerCount; ++i) {
       _setSignerValidity(signerAddresses[i], signerHat, true);
     }
 
@@ -1321,7 +1321,7 @@ contract ClaimingSignersFor is WithHSGInstanceTest {
     // create the arrays for the remaining signers
     address[] memory claimers = new address[](_signerCount);
     uint256[] memory hatIds = new uint256[](_signerCount);
-    for (uint256 i; i < _signerCount; i++) {
+    for (uint256 i; i < _signerCount; ++i) {
       claimers[i] = signerAddresses[i];
       hatIds[i] = signerHat;
     }
@@ -1336,7 +1336,7 @@ contract ClaimingSignersFor is WithHSGInstanceTest {
     _signerCount = bound(_signerCount, 1, signerAddresses.length);
 
     // set up signer validity
-    for (uint256 i; i < _signerCount; i++) {
+    for (uint256 i; i < _signerCount; ++i) {
       _setSignerValidity(signerAddresses[i], signerHat, true);
     }
 
@@ -1347,7 +1347,7 @@ contract ClaimingSignersFor is WithHSGInstanceTest {
     // create the necessary arrays
     address[] memory claimers = new address[](_signerCount);
     uint256[] memory hatIds = new uint256[](_signerCount - 1);
-    for (uint256 i; i < _signerCount - 1; i++) {
+    for (uint256 i; i < _signerCount - 1; ++i) {
       claimers[i] = signerAddresses[i];
       hatIds[i] = signerHat;
     }

--- a/test/TestSuite.t.sol
+++ b/test/TestSuite.t.sol
@@ -134,11 +134,11 @@ abstract contract SafeTestHelpers is Test {
     if (i == j) return;
     uint256 pivot = _arr[uint256(_left + (_right - _left) / 2)];
     while (i <= j) {
-      while (_arr[uint256(i)] < pivot) i++;
+      while (_arr[uint256(i)] < pivot) ++i;
       while (pivot < _arr[uint256(j)]) j--;
       if (i <= j) {
         (_arr[uint256(i)], _arr[uint256(j)]) = (_arr[uint256(j)], _arr[uint256(i)]);
-        i++;
+        ++i;
         j--;
       }
     }
@@ -149,14 +149,10 @@ abstract contract SafeTestHelpers is Test {
   function _findPrevOwner(address[] memory _owners, address _owner) internal pure returns (address prevOwner) {
     prevOwner = SENTINELS;
 
-    for (uint256 i; i < _owners.length;) {
+    for (uint256 i; i < _owners.length; ++i) {
       if (_owners[i] == _owner) {
         if (i == 0) break;
         prevOwner = _owners[i - 1];
-      }
-      // shouldn't overflow given reasonable _owners array length
-      unchecked {
-        ++i;
       }
     }
   }
@@ -273,7 +269,7 @@ contract TestSuite is SafeTestHelpers {
     tophat = hats.mintTopHat(org, "tophat", "https://hats.com");
     ownerHat = hats.createHat(tophat, "owner", 10, eligibility, toggle, true, "");
 
-    for (uint256 i = 0; i < signerHatCount; i++) {
+    for (uint256 i = 0; i < signerHatCount; ++i) {
       signerHats[i] =
         hats.createHat(tophat, string.concat("signerHat", vm.toString(i)), 100, eligibility, toggle, true, "image");
     }
@@ -380,7 +376,7 @@ contract TestSuite is SafeTestHelpers {
     //////////////////////////////////////////////////////////////*/
 
   function _addSignersSameHat(uint256 _count, uint256 _hat) internal {
-    for (uint256 i = 0; i < _count; i++) {
+    for (uint256 i = 0; i < _count; ++i) {
       _setSignerValidity(signerAddresses[i], _hat, true);
       vm.prank(signerAddresses[i]);
       hatsSignerGate.claimSigner(_hat);
@@ -388,7 +384,7 @@ contract TestSuite is SafeTestHelpers {
   }
 
   function _addSignersDifferentHats(uint256 _count, uint256[] memory _hats) internal {
-    for (uint256 i = 0; i < _count; i++) {
+    for (uint256 i = 0; i < _count; ++i) {
       _setSignerValidity(signerAddresses[i], _hats[i], true);
       vm.prank(signerAddresses[i]);
       hatsSignerGate.claimSigner(_hats[i]);
@@ -409,7 +405,7 @@ contract TestSuite is SafeTestHelpers {
   }
 
   function assertValidSignerHats(uint256[] memory _signerHats) public {
-    for (uint256 i = 0; i < _signerHats.length; i++) {
+    for (uint256 i = 0; i < _signerHats.length; ++i) {
       assertTrue(hatsSignerGate.validSignerHats(_signerHats[i]));
     }
   }

--- a/test/TestSuite.t.sol
+++ b/test/TestSuite.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import { Test, console2 } from "forge-std/Test.sol";
-import { IHats } from "hats-protocol/Interfaces/IHats.sol";
+import { Test, console2 } from "../lib/forge-std/src/Test.sol";
+import { IHats } from "../lib/hats-protocol/src/Interfaces/IHats.sol";
 import { HatsSignerGate } from "../src/HatsSignerGate.sol";
 import { ISafe } from "../src/lib/safe-interfaces/ISafe.sol";
 import { SafeProxyFactory } from "../lib/safe-smart-account/contracts/proxies/SafeProxyFactory.sol";


### PR DESCRIPTION
- use solc 0.8.26
- which lets us move events to IHatsSignerGate and get rid of the HSGEvents library
- also lets us get rid of the `unchecked` keyword around for loop iterators, since solc now handles that automatically
- use relative import paths
- consolidate natspec to within IHatsSignerGate
- cache `safe` state reads within the guard functions to save a little gas