### PR TITLE
Set initial modules and guard

### DIFF
--- a/script/HatsSignerGate.s.sol
+++ b/script/HatsSignerGate.s.sol
@@ -62,7 +62,8 @@ contract DeployImplementation is BaseScript {
 
     if (verbose) {
       console2.log("HSG implementation", address(implementation));
-      console2.log("HSG code size", address(implementation).code.length);
+      console2.log("HSG runtime bytecode size", address(implementation).code.length);
+      console2.log("HSG runtime bytecode margin", 24_576 - (address(implementation).code.length));
       console2.log("Safe singleton", safeSingleton);
       console2.log("Safe fallback library", safeFallbackLibrary);
       console2.log("Safe multisend library", safeMultisendLibrary);
@@ -80,7 +81,7 @@ contract DeployInstance is BaseScript {
   address public hats;
   address public implementation;
   address public instance;
-
+  address public hsgGuard;
   uint256 public saltNonce;
 
   uint256 public ownerHat;
@@ -91,8 +92,7 @@ contract DeployInstance is BaseScript {
   bool public locked;
   bool public claimableFor;
 
-  function prepare(
-    bool _verbose,
+  function prepare1(
     address _implementation,
     uint256 _ownerHat,
     uint256[] memory _signersHats,
@@ -101,9 +101,8 @@ contract DeployInstance is BaseScript {
     address _safe,
     bool _locked,
     bool _claimableFor,
-    uint256 _saltNonce
+    address _hsgGuard
   ) public {
-    verbose = _verbose;
     implementation = _implementation;
     ownerHat = _ownerHat;
     signersHats = _signersHats;
@@ -112,6 +111,11 @@ contract DeployInstance is BaseScript {
     safe = _safe;
     locked = _locked;
     claimableFor = _claimableFor;
+    hsgGuard = _hsgGuard;
+  }
+
+  function prepare2(bool _verbose, uint256 _saltNonce) public {
+    verbose = _verbose;
     saltNonce = _saltNonce;
   }
 
@@ -136,7 +140,8 @@ contract DeployInstance is BaseScript {
       targetThreshold: targetThreshold,
       locked: locked,
       claimableFor: claimableFor,
-      implementation: implementation
+      implementation: implementation,
+      hsgGuard: hsgGuard
     });
     return params;
   }

--- a/script/HatsSignerGate.s.sol
+++ b/script/HatsSignerGate.s.sol
@@ -82,6 +82,7 @@ contract DeployInstance is BaseScript {
   address public implementation;
   address public instance;
   address public hsgGuard;
+  address[] public hsgModules;
   uint256 public saltNonce;
 
   uint256 public ownerHat;
@@ -101,7 +102,8 @@ contract DeployInstance is BaseScript {
     address _safe,
     bool _locked,
     bool _claimableFor,
-    address _hsgGuard
+    address _hsgGuard,
+    address[] memory _hsgModules
   ) public {
     implementation = _implementation;
     ownerHat = _ownerHat;
@@ -112,6 +114,7 @@ contract DeployInstance is BaseScript {
     locked = _locked;
     claimableFor = _claimableFor;
     hsgGuard = _hsgGuard;
+    hsgModules = _hsgModules;
   }
 
   function prepare2(bool _verbose, uint256 _saltNonce) public {
@@ -141,7 +144,8 @@ contract DeployInstance is BaseScript {
       locked: locked,
       claimableFor: claimableFor,
       implementation: implementation,
-      hsgGuard: hsgGuard
+      hsgGuard: hsgGuard,
+      hsgModules: hsgModules
     });
     return params;
   }

--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -35,17 +35,17 @@ contract HatsSignerGate is
   /// @inheritdoc IHatsSignerGate
   IHats public immutable HATS;
 
-  /// @inheritdoc IHatsSignerGate
-  address public immutable safeSingleton;
+  /// @dev The address of the Safe singleton contract used to deploy new Safes
+  address internal immutable SAFE_SINGLETON;
 
-  /// @inheritdoc IHatsSignerGate
-  address public immutable safeFallbackLibrary;
+  /// @dev The address of the Safe fallback library used to deploy new Safes
+  address internal immutable SAFE_FALLBACK_LIBRARY;
 
-  /// @inheritdoc IHatsSignerGate
-  address public immutable safeMultisendLibrary;
+  /// @dev The address of the Safe multisend library used to deploy new Safes
+  address internal immutable SAFE_MULTISEND_LIBRARY;
 
-  /// @inheritdoc IHatsSignerGate
-  address public immutable safeProxyFactory;
+  /// @dev The address of the Safe proxy factory used to deploy new Safes
+  address internal immutable SAFE_PROXY_FACTORY;
 
   /// @inheritdoc IHatsSignerGate
   string public constant version = "2.0.0";
@@ -113,10 +113,10 @@ contract HatsSignerGate is
     address _safeProxyFactory
   ) initializer {
     HATS = IHats(_hats);
-    safeProxyFactory = _safeProxyFactory;
-    safeSingleton = _safeSingleton;
-    safeFallbackLibrary = _safeFallbackLibrary;
-    safeMultisendLibrary = _safeMultisendLibrary;
+    SAFE_PROXY_FACTORY = _safeProxyFactory;
+    SAFE_SINGLETON = _safeSingleton;
+    SAFE_FALLBACK_LIBRARY = _safeFallbackLibrary;
+    SAFE_MULTISEND_LIBRARY = _safeMultisendLibrary;
 
     // set the implementation's owner hat to a nonexistent hat to prevent state changes to the implementation
     ownerHat = 1;
@@ -133,7 +133,7 @@ contract HatsSignerGate is
     // deploy a new safe if there is no provided safe
     if (params.safe == address(0)) {
       params.safe = SafeManagerLib.deploySafeAndAttachHSG(
-        safeProxyFactory, safeSingleton, safeFallbackLibrary, safeMultisendLibrary
+        SAFE_PROXY_FACTORY, SAFE_SINGLETON, SAFE_FALLBACK_LIBRARY, SAFE_MULTISEND_LIBRARY
       );
     }
 
@@ -531,6 +531,20 @@ contract HatsSignerGate is
         }
       }
     }
+  }
+
+  /// @inheritdoc IHatsSignerGate
+  function getSafeDeployParamAddresses()
+    public
+    view
+    returns (
+      address _safeSingleton,
+      address _safeFallbackLibrary,
+      address _safeMultisendLibrary,
+      address _safeProxyFactory
+    )
+  {
+    return (SAFE_SINGLETON, SAFE_FALLBACK_LIBRARY, SAFE_MULTISEND_LIBRARY, SAFE_PROXY_FACTORY);
   }
 
   /*//////////////////////////////////////////////////////////////

--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -159,7 +159,9 @@ contract HatsSignerGate is
     setupModules();
 
     // TODO set any initial modules
-    // TODO set the initial guard
+
+    // set the initial guard, if any
+    if (params.hsgGuard != address(0)) _setGuard(params.hsgGuard);
   }
 
   /*//////////////////////////////////////////////////////////////
@@ -833,11 +835,12 @@ contract HatsSignerGate is
                       ZODIAC GUARD FUNCTIONS
   //////////////////////////////////////////////////////////////*/
 
-  /// @inheritdoc GuardableUnowned
+  /// @notice Set a guard that checks transactions before execution.
   /// @dev Only callable by a wearer of the owner hat, and only if the contract is not locked.
-  function setGuard(address guard) public override {
+  /// @param _guard The address of the guard to be used or the 0 address to disable the guard.
+  function setGuard(address _guard) public {
     _checkUnlocked();
     _checkOwner();
-    super.setGuard(guard);
+    _setGuard(_guard);
   }
 }

--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -155,10 +155,11 @@ contract HatsSignerGate is
     // set the instance's metadata
     implementation = params.implementation;
 
-    // initialize the modules linked list
+    // initialize the modules linked list, and set initial modules, if any
     setupModules();
-
-    // TODO set any initial modules
+    for (uint256 i; i < params.hsgModules.length; ++i) {
+      _enableModule(params.hsgModules[i]);
+    }
 
     // set the initial guard, if any
     if (params.hsgGuard != address(0)) _setGuard(params.hsgGuard);
@@ -837,12 +838,13 @@ contract HatsSignerGate is
     super.disableModule(prevModule, module);
   }
 
-  /// @inheritdoc ModifierUnowned
+  /// @notice Enables a module that can add transactions to the queue
   /// @dev Only callable by a wearer of the owner hat, and only if the contract is not locked.
-  function enableModule(address module) public override {
+  /// @param module Address of the module to be enabled
+  function enableModule(address module) public {
     _checkUnlocked();
     _checkOwner();
-    super.enableModule(module);
+    _enableModule(module);
   }
 
   /*//////////////////////////////////////////////////////////////

--- a/src/interfaces/IHatsSignerGate.sol
+++ b/src/interfaces/IHatsSignerGate.sol
@@ -131,18 +131,6 @@ interface IHatsSignerGate {
   /// @notice The Hats Protocol contract address
   function HATS() external view returns (IHats);
 
-  /// @notice The Safe singleton contract address
-  function safeSingleton() external view returns (address);
-
-  /// @notice The Safe fallback library contract address
-  function safeFallbackLibrary() external view returns (address);
-
-  /// @notice The Safe multisend library contract address
-  function safeMultisendLibrary() external view returns (address);
-
-  /// @notice The Safe proxy factory contract address
-  function safeProxyFactory() external view returns (address);
-
   /// @notice The version of this HatsSignerGate contract
   function version() external view returns (string memory);
 
@@ -293,4 +281,19 @@ interface IHatsSignerGate {
     external
     view
     returns (uint256 validSigCount);
+
+  /// @notice Returns the addresses of the Safe contracts used to deploy new Safes
+  /// @return _safeSingleton The address of the Safe singleton used to deploy new Safes
+  /// @return _safeFallbackLibrary The address of the Safe fallback library used to deploy new Safes
+  /// @return _safeMultisendLibrary The address of the Safe multisend library used to deploy new Safes
+  /// @return _safeProxyFactory The address of the Safe proxy factory used to deploy new Safes
+  function getSafeDeployParamAddresses()
+    external
+    view
+    returns (
+      address _safeSingleton,
+      address _safeFallbackLibrary,
+      address _safeMultisendLibrary,
+      address _safeProxyFactory
+    );
 }

--- a/src/interfaces/IHatsSignerGate.sol
+++ b/src/interfaces/IHatsSignerGate.sol
@@ -19,6 +19,7 @@ interface IHatsSignerGate {
   /// @param locked Whether the contract is locked
   /// @param claimableFor Whether signer permissions can be claimed on behalf of valid hat wearers
   /// @param implementation The address of the HatsSignerGate implementation
+  /// @param hsgGuard The address of the initial guard set on the HatsSignerGate instance
   struct SetupParams {
     uint256 ownerHat;
     uint256[] signerHats;
@@ -28,6 +29,7 @@ interface IHatsSignerGate {
     bool locked;
     bool claimableFor;
     address implementation;
+    address hsgGuard;
   }
 
   /*//////////////////////////////////////////////////////////////

--- a/src/interfaces/IHatsSignerGate.sol
+++ b/src/interfaces/IHatsSignerGate.sol
@@ -20,6 +20,7 @@ interface IHatsSignerGate {
   /// @param claimableFor Whether signer permissions can be claimed on behalf of valid hat wearers
   /// @param implementation The address of the HatsSignerGate implementation
   /// @param hsgGuard The address of the initial guard set on the HatsSignerGate instance
+  /// @param hsgModules The initial modules set on the HatsSignerGate instance
   struct SetupParams {
     uint256 ownerHat;
     uint256[] signerHats;
@@ -30,6 +31,7 @@ interface IHatsSignerGate {
     bool claimableFor;
     address implementation;
     address hsgGuard;
+    address[] hsgModules;
   }
 
   /*//////////////////////////////////////////////////////////////

--- a/src/lib/zodiac-modified/GuardableUnowned.sol
+++ b/src/lib/zodiac-modified/GuardableUnowned.sol
@@ -17,7 +17,7 @@ contract GuardableUnowned {
 
   /// @dev Set a guard that checks transactions before execution.
   /// @param _guard The address of the guard to be used or the 0 address to disable the guard.
-  function setGuard(address _guard) public virtual {
+  function _setGuard(address _guard) internal virtual {
     if (_guard != address(0)) {
       if (!BaseGuard(_guard).supportsInterface(type(IGuard).interfaceId)) {
         revert NotIERC165Compliant(_guard);

--- a/src/lib/zodiac-modified/ModifierUnowned.sol
+++ b/src/lib/zodiac-modified/ModifierUnowned.sol
@@ -67,25 +67,9 @@ abstract contract ModifierUnowned is ExecutionTracker, SignatureChecker, IAvatar
     --------------------------------------------------
     */
 
-  // TODO potentially simplify to save code size
+  /// @dev Simplified version of the moduleOnly modifier from Zodiac
   modifier moduleOnly() {
-    if (modules[msg.sender] == address(0)) {
-      (bytes32 hash, address signer) = moduleTxSignedBy();
-
-      // is the signer a module?
-      if (modules[signer] == address(0)) {
-        revert NotAuthorized(msg.sender);
-      }
-
-      // is the provided signature fresh?
-      if (consumed[signer][hash]) {
-        revert HashAlreadyConsumed(hash);
-      }
-
-      consumed[signer][hash] = true;
-      emit HashExecuted(hash);
-    }
-
+    if (modules[msg.sender] == address(0)) revert NotAuthorized(msg.sender);
     _;
   }
 

--- a/src/lib/zodiac-modified/ModifierUnowned.sol
+++ b/src/lib/zodiac-modified/ModifierUnowned.sol
@@ -2,14 +2,13 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 import { Enum } from "../../lib/safe-interfaces/ISafe.sol";
-import { ExecutionTracker } from "../../../lib/zodiac/contracts/signature/ExecutionTracker.sol";
 import { IAvatar } from "../../../lib/zodiac/contracts/interfaces/IAvatar.sol";
-import { SignatureChecker } from "../../../lib/zodiac/contracts/signature/SignatureChecker.sol";
 
 /// @title ModifierUnowned - A contract that sits between a Module and an Avatar and enforces some additional logic.
 /// @author Gnosis Guild
-/// @dev Modified from Zodiac's Modifier to enable inheriting contracts to use their preferred owner logic.
-abstract contract ModifierUnowned is ExecutionTracker, SignatureChecker, IAvatar {
+/// @dev Modified from Zodiac's Modifier to enable inheriting contracts to use their preferred owner logic
+/// and to simplify the moduleOnly modifier.
+abstract contract ModifierUnowned is IAvatar {
   address internal constant SENTINEL_MODULES = address(0x1);
   /// Mapping of modules.
   mapping(address => address) internal modules;

--- a/src/lib/zodiac-modified/ModifierUnowned.sol
+++ b/src/lib/zodiac-modified/ModifierUnowned.sol
@@ -90,7 +90,7 @@ abstract contract ModifierUnowned is ExecutionTracker, SignatureChecker, IAvatar
   /// @notice Enables a module that can add transactions to the queue
   /// @dev Should be overridden to restrict access, such as to an owner
   /// @param module Address of the module to be enabled
-  function enableModule(address module) public virtual {
+  function _enableModule(address module) internal virtual {
     if (module == address(0) || module == SENTINEL_MODULES) {
       revert InvalidModule(module);
     }

--- a/test/TestSuite.t.sol
+++ b/test/TestSuite.t.sol
@@ -259,7 +259,12 @@ contract TestSuite is SafeTestHelpers {
   uint256 public minThreshold;
   uint256 public targetThreshold;
   bool public locked;
-  TestGuard public testGuard;
+  TestGuard public tstGuard;
+  address[] public tstModules;
+  address public tstModule1 = makeAddr("tstModule1");
+  address public tstModule2 = makeAddr("tstModule2");
+  address public tstModule3 = makeAddr("tstModule3");
+
   // Utility variables
   address[] initSafeOwners = new address[](1);
 
@@ -284,7 +289,13 @@ contract TestSuite is SafeTestHelpers {
     (pks, signerAddresses) = _createAddressesFromPks(10);
 
     // create the test guard
-    testGuard = new TestGuard(address(hatsSignerGate));
+    tstGuard = new TestGuard(address(hatsSignerGate));
+
+    // set up the test modules array
+    tstModules = new address[](3);
+    tstModules[0] = tstModule1;
+    tstModules[1] = tstModule2;
+    tstModules[2] = tstModule3;
 
     // Set up the test hats
     uint256 signerHatCount = 5;
@@ -340,6 +351,7 @@ contract TestSuite is SafeTestHelpers {
     bool _locked,
     bool _claimableFor,
     address _hsgGuard,
+    address[] memory _hsgModules,
     bytes4 _expectedError,
     bool _verbose
   ) internal returns (HatsSignerGate) {
@@ -354,7 +366,8 @@ contract TestSuite is SafeTestHelpers {
       _safe,
       _locked,
       _claimableFor,
-      _hsgGuard
+      _hsgGuard,
+      _hsgModules
     );
     instanceDeployer.prepare2(_verbose, TEST_SALT_NONCE);
 
@@ -374,7 +387,8 @@ contract TestSuite is SafeTestHelpers {
     bool _locked,
     bool _verbose,
     bool _claimableFor,
-    address _hsgGuard
+    address _hsgGuard,
+    address[] memory _hsgModules
   ) internal returns (HatsSignerGate _hatsSignerGate, ISafe _safe) {
     // create the instance deployer
     DeployInstance instanceDeployer = new DeployInstance();
@@ -387,7 +401,8 @@ contract TestSuite is SafeTestHelpers {
       address(0),
       _locked,
       _claimableFor,
-      _hsgGuard
+      _hsgGuard,
+      _hsgModules
     );
     instanceDeployer.prepare2(_verbose, TEST_SALT_NONCE);
     _hatsSignerGate = instanceDeployer.run();
@@ -450,6 +465,7 @@ contract WithHSGInstanceTest is TestSuite {
       _locked: false,
       _claimableFor: false,
       _hsgGuard: address(0), // no guard
+      _hsgModules: new address[](0), // no modules
       _verbose: false
     });
   }


### PR DESCRIPTION
This PR adds the ability for deployers of HSG instances to optionally set a guard and modules on HSG itself.

Note that as currently defined, the bytecode size of HatsSignerGate.sol is 22,584 bytes, just 1992 under the max. Two of the commits in this PR — a487c0f407cce377d0d29b7fece1bbc2224778eb and 1cd4e661716635392e45a4d3100824b035b3dfdc — make small tweaks / simplifications in order to reduce the bytecode size.