### PR TITLE
Delegatecall guard & transient storage

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "lib/openzeppelin-contracts"]
+	path = lib/openzeppelin-contracts
+	url = https://github.com/openzeppelin/openzeppelin-contracts

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "lib/hats-auth"]
-	path = lib/hats-auth
-	url = https://github.com/Hats-Protocol/hats-auth
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/openzeppelin/openzeppelin-contracts

--- a/foundry.toml
+++ b/foundry.toml
@@ -7,7 +7,8 @@ optimizer_runs = 1_000_000
 bytecode_hash = "none"
 gas_reports = ["*"]
 auto_detect_solc = false
-solc = "0.8.26"
+solc = "0.8.28"
+evm_version = "cancun"
 fs_permissions = [{ access = "read", path = "./"}]
 remappings = [
   "solmate/=lib/solmate/src/",

--- a/gasreport.ansi
+++ b/gasreport.ansi
@@ -1,141 +1,170 @@
-Compiling 4 files with Solc 0.8.20
-Solc 0.8.20 finished in 8.16s
-Compiler run successful!
+No files changed, compilation skipped
+
+Ran 1 test for test/HatsSignerGate.t.sol:EnablingHSGModules
+[PASS] test_happy() (gas: 92509)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.00s (92.27ms CPU time)
 
 Ran 2 tests for test/HatsSignerGate.t.sol:GuardFunctionAuth
-[PASS] testCannotCallCheckAfterExecutionFromNonSafe() (gas: 34657)
-[PASS] testCannotCallCheckTransactionFromNonSafe() (gas: 38123)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 379.15ms (1.43ms CPU time)
+[PASS] testCannotCallCheckAfterExecutionFromNonSafe() (gas: 34638)
+[PASS] testCannotCallCheckTransactionFromNonSafe() (gas: 38328)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.14s (272.94ms CPU time)
 
-Ran 3 tests for test/HatsSignerGate.t.sol:DetachingHSG
-[PASS] test_happy() (gas: 91086)
-[PASS] test_revert_locked() (gas: 127331)
-[PASS] test_revert_nonOwner() (gas: 73190)
-Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 380.91ms (3.86ms CPU time)
+Ran 1 test for test/HatsSignerGate.t.sol:ClaimingSigners
+[PASS] test_happy() (gas: 259711)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.14s (260.72ms CPU time)
 
-Ran 4 tests for test/HatsSignerGate.t.sol:SettingMinThreshold
-[PASS] testNonOwnerCannotSetMinThreshold() (gas: 61429)
-[PASS] testSetInvalidMinThreshold() (gas: 60137)
-[PASS] testSetMinThreshold() (gas: 151859)
-[PASS] test_revert_locked() (gas: 109965)
-Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 382.48ms (6.66ms CPU time)
+Ran 1 test for test/HatsSignerGate.t.sol:HSGGuarding
+[PASS] test_executed() (gas: 468016)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.38s (87.23ms CPU time)
 
-Ran 3 tests for test/HatsSignerGate.t.sol:MigratingHSG
-[PASS] test_happy() (gas: 151577)
-[PASS] test_revert_locked() (gas: 112373)
-[PASS] test_revert_nonOwner() (gas: 58232)
-Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 382.72ms (3.13ms CPU time)
+Ran 2 tests for test/HatsSignerGate.t.sol:ClaimingSignerFor
+[PASS] test_happy() (gas: 319686)
+[PASS] test_happy_alreadyOwnerNotRegistered() (gas: 344434)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.55s (663.62ms CPU time)
 
-Ran 5 tests for test/HatsSignerGate.t.sol:ClaimingSignerFor
-[PASS] test_happy() (gas: 319243)
-[PASS] test_revert_alreadyClaimed() (gas: 404040)
-[PASS] test_revert_invalidSigner() (gas: 225401)
-[PASS] test_revert_invalidSignerHat() (gas: 271466)
-[PASS] test_revert_notClaimableFor() (gas: 283302)
-Suite result: ok. 5 passed; 0 failed; 0 skipped; finished in 510.39ms (135.20ms CPU time)
+Ran 2 tests for test/HatsSignerGate.t.sol:ExecutingFromModuleReturnDataViaHSG
+[PASS] test_happy_executionFailure() (gas: 67370)
+[PASS] test_happy_executionSuccess() (gas: 104555)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.12s (163.05ms CPU time)
 
-Ran 4 tests for test/HatsSignerGate.t.sol:AddingSigners
-[PASS] testAddSingleSigner() (gas: 266837)
-[PASS] testAddThreeSigners() (gas: 766843)
-[PASS] test_Multi_AddSingleSigner() (gas: 275167)
-[PASS] test_Multi_AddTwoSigners_DifferentHats() (gas: 530107)
-Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 514.00ms (260.46ms CPU time)
+Ran 1 test for test/HatsSignerGate.t.sol:SettingOwnerHat
+[PASS] test_happy() (gas: 65640)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.64s (79.55ms CPU time)
 
-Ran 7 tests for test/HatsSignerGate.t.sol:RemovingSigners
-[PASS] testCanRemoveInvalidSigner1() (gas: 399279)
-[PASS] testCanRemoveInvalidSignerAfterReconcile2Signers() (gas: 745240)
-[PASS] testCanRemoveInvalidSignerAfterReconcile3PLusSigners() (gas: 1015577)
-[PASS] testCanRemoveInvalidSignerWhenMultipleSigners() (gas: 640866)
-[PASS] testCannotRemoveValidSigner() (gas: 324512)
-[PASS] test_Multi_CanRemoveInvalidSigner1() (gas: 412477)
-[PASS] test_Multi_CannotRemoveValidSigner() (gas: 335756)
-Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 517.54ms (141.55ms CPU time)
+Ran 2 tests for test/HatsSignerGate.t.sol:SettingHSGGuard
+[PASS] test_happy() (gas: 90318)
+[PASS] test_removeGuard() (gas: 64437)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.18s (257.85ms CPU time)
 
-Ran 6 tests for test/HatsSignerGate.t.sol:ExecutingTransactions
-[PASS] testExecByLessThanMinThresholdReverts() (gas: 876991)
-[PASS] testExecTxByHatWearers() (gas: 1295054)
-[PASS] testExecTxByNonHatWearersReverts() (gas: 1294922)
-[PASS] testExecTxByTooFewOwnersReverts() (gas: 497379)
-[PASS] test_Multi_ExecTxByHatWearers() (gas: 1334609)
-[PASS] test_Multi_ExecTxByNonHatWearersReverts() (gas: 1336647)
-Suite result: ok. 6 passed; 0 failed; 0 skipped; finished in 520.71ms (275.40ms CPU time)
+Ran 2 tests for test/HatsSignerGate.t.sol:ExecutingFromModuleViaHSG
+[PASS] test_happy_executionFailure() (gas: 65811)
+[PASS] test_happy_executionSuccess() (gas: 102996)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 1.83s (175.22ms CPU time)
 
 Ran 7 tests for test/HatsSignerGate.t.sol:ConstrainingSigners
-[PASS] testCannotDecreaseThreshold() (gas: 1189360)
-[PASS] testCannotDisableGuard() (gas: 911623)
-[PASS] testCannotDisableModule() (gas: 939594)
-[PASS] testCannotIncreaseThreshold() (gas: 1189358)
-[PASS] testSignersCannotAddOwners() (gas: 1233420)
-[PASS] testSignersCannotRemoveOwners() (gas: 1201906)
-[PASS] testSignersCannotSwapOwners() (gas: 1233969)
-Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 520.71ms (152.41ms CPU time)
+[PASS] testCannotDecreaseThreshold() (gas: 1184890)
+[PASS] testCannotDisableGuard() (gas: 908081)
+[PASS] testCannotDisableModule() (gas: 932190)
+[PASS] testCannotIncreaseThreshold() (gas: 1184888)
+[PASS] testSignersCannotAddOwners() (gas: 1224040)
+[PASS] testSignersCannotRemoveOwners() (gas: 1193787)
+[PASS] testSignersCannotSwapOwners() (gas: 1225292)
+Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 6.06s (4.18s CPU time)
+
+Ran 3 tests for test/HatsSignerGate.t.sol:SettingMinThreshold
+[PASS] testNonOwnerCannotSetMinThreshold() (gas: 63889)
+[PASS] testSetInvalidMinThreshold() (gas: 60185)
+[PASS] testSetMinThreshold() (gas: 152261)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 2.09s (376.16ms CPU time)
+
+Ran 1 test for test/HatsSignerGate.t.sol:DisablingDelegatecallTargets
+[PASS] test_happy() (gas: 60799)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.04s (96.26ms CPU time)
+
+Ran 1 test for test/HatsSignerGate.t.sol:EnablingDelegatecallTargets
+[PASS] test_happy() (gas: 87475)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.78s (82.45ms CPU time)
+
+Ran 4 tests for test/HatsSignerGate.t.sol:SettingTargetThreshold
+[PASS] testNonOwnerHatWearerCannotSetTargetThreshold() (gas: 76505)
+[PASS] testSetTargetThreshold() (gas: 346376)
+[PASS] testSetTargetThreshold3of4() (gas: 1142955)
+[PASS] testSetTargetThreshold4of4() (gas: 1142940)
+Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 4.82s (1.96s CPU time)
+
+Ran 7 tests for test/HatsSignerGate.t.sol:ExecutingTransactions
+[PASS] testExecByLessThanMinThresholdReverts() (gas: 900799)
+[PASS] testExecTxByHatWearers() (gas: 1286917)
+[PASS] testExecTxByNonHatWearersReverts() (gas: 1280923)
+[PASS] testExecTxByTooFewOwnersReverts() (gas: 519432)
+[PASS] test_Multi_ExecTxByHatWearers() (gas: 1326427)
+[PASS] test_Multi_ExecTxByNonHatWearersReverts() (gas: 1322603)
+[PASS] test_happy_delegateCall() (gas: 1290504)
+Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 9.45s (4.33s CPU time)
+
+Ran 1 test for test/HatsSignerGate.t.sol:DetachingHSG
+[PASS] test_happy() (gas: 92373)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.71s (79.09ms CPU time)
+
+Ran 4 tests for test/HatsSignerGate.t.sol:AddingSigners
+[PASS] testAddSingleSigner() (gas: 267798)
+[PASS] testAddThreeSigners() (gas: 767436)
+[PASS] test_Multi_AddSingleSigner() (gas: 275773)
+[PASS] test_Multi_AddTwoSigners_DifferentHats() (gas: 530748)
+Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 9.45s (1.29s CPU time)
+
+Ran 1 test for test/HatsSignerGate.t.sol:DisablingHSGModules
+[PASS] test_happy() (gas: 66099)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.96s (66.81ms CPU time)
+
+Ran 6 tests for test/HatsSignerGate.t.sol:RemovingSigners
+[PASS] testCanRemoveInvalidSigner1() (gas: 395503)
+[PASS] testCanRemoveInvalidSignerWhenMultipleSigners() (gas: 634831)
+[PASS] testCannotRemoveValidSigner() (gas: 315471)
+[PASS] testValidSignerCanClaimAfterPrevRemoved() (gas: 617964)
+[PASS] test_Multi_CanRemoveInvalidSigner1() (gas: 406795)
+[PASS] test_Multi_CannotRemoveValidSigner() (gas: 326669)
+Suite result: ok. 6 passed; 0 failed; 0 skipped; finished in 5.74s (2.36s CPU time)
 
 Ran 8 tests for test/HatsSignerGate.attacks.t.sol:AttacksScenarios
-[PASS] testAttackerCannotExploitSigHandlingDifferences() (gas: 1723905)
-[PASS] testCanClaimToReplaceInvalidSignerAtMaxSigner() (gas: 1608698)
-[PASS] testRemoveSignerCorrectlyUpdates() (gas: 1575859)
-[PASS] testSetTargetThresholdUpdatesThresholdCorrectly() (gas: 1545610)
-[PASS] testSetTargetTresholdCannotSetBelowMinThreshold() (gas: 70984)
-[PASS] testSignersCannotAddNewModules() (gas: 956462)
-[PASS] testSignersCannotReenterCheckTransactionToAddOwners() (gas: 1400594)
-[PASS] testTargetSigAttackFails() (gas: 2294663)
-Suite result: ok. 8 passed; 0 failed; 0 skipped; finished in 520.69ms (161.47ms CPU time)
+[PASS] testAttackerCannotExploitSigHandlingDifferences() (gas: 1706567)
+[PASS] testCanClaimToReplaceInvalidSignerAtMaxSigner() (gas: 1607255)
+[PASS] testRemoveSignerCorrectlyUpdates() (gas: 1569387)
+[PASS] testSetTargetThresholdUpdatesThresholdCorrectly() (gas: 1544580)
+[PASS] testSetTargetTresholdCannotSetBelowMinThreshold() (gas: 72346)
+[PASS] testSignersCannotAddNewModules() (gas: 948988)
+[PASS] testSignersCannotReenterCheckTransactionToAddOwners() (gas: 1396072)
+[PASS] testTargetSigAttackFails() (gas: 1966784)
+Suite result: ok. 8 passed; 0 failed; 0 skipped; finished in 9.50s (7.49s CPU time)
 
-Ran 4 tests for test/HatsSignerGate.t.sol:AddingSignerHats
-[PASS] test_Multi_NonOwnerCannotAddSignerHats() (gas: 56734)
-[PASS] test_Multi_OwnerCanAddSignerHats(uint256) (runs: 259, μ: 321587, ~: 109031)
-[PASS] test_Multi_OwnerCanAddSignerHats1() (gas: 85590)
-[PASS] test_revert_locked() (gas: 110971)
-Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 585.56ms (209.84ms CPU time)
+Ran 3 tests for test/HatsSignerGate.t.sol:AddingSignerHats
+[PASS] test_Multi_NonOwnerCannotAddSignerHats() (gas: 58914)
+[PASS] test_Multi_OwnerCanAddSignerHats(uint256) (runs: 256, μ: 356398, ~: 108992)
+[PASS] test_Multi_OwnerCanAddSignerHats1() (gas: 85605)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 18.79s (17.09s CPU time)
 
-Ran 4 tests for test/HatsSignerGate.t.sol:ClaimingSigners
-[PASS] test_happy() (gas: 259015)
-[PASS] test_revert_alreadyClaimed() (gas: 594831)
-[PASS] test_revert_invalidSigner() (gas: 128783)
-[PASS] test_revert_multi_invalidSigner(uint256) (runs: 257, μ: 131629, ~: 131629)
-Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 682.87ms (306.61ms CPU time)
+Ran 1 test for test/HatsSignerGate.t.sol:SettingClaimableFor
+[PASS] test_happy(bool) (runs: 257, μ: 63970, ~: 65349)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 16.03s (14.07s CPU time)
 
-Ran 5 tests for test/HatsSignerGate.t.sol:SettingTargetThreshold
-[PASS] testNonOwnerHatWearerCannotSetTargetThreshold() (gas: 73646)
-[PASS] testSetTargetThreshold() (gas: 345982)
-[PASS] testSetTargetThreshold3of4() (gas: 1143634)
-[PASS] testSetTargetThreshold4of4() (gas: 1143705)
-[PASS] test_revert_locked() (gas: 109987)
-Suite result: ok. 5 passed; 0 failed; 0 skipped; finished in 319.08ms (7.50ms CPU time)
+Ran 2 tests for test/HatsSignerGate.t.sol:Deployment
+[PASS] test_andSafe(bool,bool) (runs: 257, μ: 2993847, ~: 2998931)
+[PASS] test_onlyHSG(bool,bool) (runs: 257, μ: 2916296, ~: 2915805)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 56.00s (99.27s CPU time)
 
-Ran 3 tests for test/HatsSignerGate.t.sol:SettingClaimableFor
-[PASS] test_happy(bool) (runs: 259, μ: 63227, ~: 64595)
-[PASS] test_revert_locked() (gas: 119322)
-[PASS] test_revert_nonOwner() (gas: 65203)
-Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 209.74ms (26.98ms CPU time)
+Ran 3 tests for test/HatsSignerGate.t.sol:ClaimingSignersFor
+[PASS] test_alreadyOwnerNotRegistered_happy(uint256) (runs: 257, μ: 1136806, ~: 1124784)
+[PASS] test_startingEmpty_happy(uint256) (runs: 257, μ: 1066672, ~: 1036790)
+[PASS] test_startingWith1Signer_happy(uint256) (runs: 257, μ: 1142520, ~: 1118935)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 113.86s (269.59s CPU time)
 
-Ran 3 tests for test/HatsSignerGate.t.sol:Deployment
-[PASS] test_andSafe(bool,bool) (runs: 259, μ: 2473691, ~: 2478879)
-[PASS] test_onlyHSG(bool,bool) (runs: 259, μ: 2397306, ~: 2397783)
-[PASS] test_revert_reinitializeImplementation() (gas: 57512)
-Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 520.56ms (350.15ms CPU time)
+Ran 2 tests for test/HatsSignerGate.t.sol:MigratingHSG
+[PASS] test_happy_claimableFor_signersToMigrate(uint256) (runs: 257, μ: 1849143, ~: 1712282)
+[PASS] test_happy_noSignersToMigrate() (gas: 155348)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 115.80s (113.76s CPU time)
 | script/HatsSignerGate.s.sol:DeployImplementation contract |                 |         |         |         |         |
 |-----------------------------------------------------------|-----------------|---------|---------|---------|---------|
 | Deployment Cost                                           | Deployment Size |         |         |         |         |
-| 5574775                                                   | 25877           |         |         |         |         |
+| 6083926                                                   | 28009           |         |         |         |         |
 | Function Name                                             | min             | avg     | median  | max     | # calls |
 | hats                                                      | 401             | 401     | 401     | 401     | 68      |
-| prepare                                                   | 32744           | 32744   | 32744   | 32744   | 68      |
-| run                                                       | 4035840         | 4035840 | 4035840 | 4035840 | 68      |
+| prepare                                                   | 26509           | 26509   | 26509   | 26509   | 68      |
+| run                                                       | 4804724         | 4804724 | 4804724 | 4804724 | 68      |
 | safeFallbackLibrary                                       | 347             | 347     | 347     | 347     | 68      |
 | safeMultisendLibrary                                      | 346             | 346     | 346     | 346     | 68      |
 | safeProxyFactory                                          | 348             | 348     | 348     | 348     | 68      |
-| safeSingleton                                             | 391             | 391     | 391     | 391     | 68      |
-| zodiacModuleFactory                                       | 369             | 369     | 369     | 369     | 68      |
+| safeSingleton                                             | 369             | 369     | 369     | 369     | 68      |
+| zodiacModuleFactory                                       | 347             | 347     | 347     | 347     | 68      |
 
 
 | script/HatsSignerGate.s.sol:DeployInstance contract |                 |        |        |        |         |
 |-----------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                     | Deployment Size |        |        |        |         |
-| 1308948                                             | 5701            |        |        |        |         |
+| 1477980                                             | 6578            |        |        |        |         |
 | Function Name                                       | min             | avg    | median | max    | # calls |
-| prepare                                             | 276306          | 291608 | 296230 | 296470 | 580     |
-| run                                                 | 441735          | 606544 | 738761 | 739773 | 580     |
+| prepare1                                            | 254422          | 365237 | 382529 | 382769 | 580     |
+| prepare2                                            | 46044           | 48822  | 48832  | 48832  | 580     |
+| run                                                 | 514247          | 773484 | 811131 | 918666 | 580     |
 
 
 | src/HatsSignerGate.sol:HatsSignerGate contract |                 |        |        |         |         |
@@ -143,33 +172,53 @@ Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 520.56ms (350.15ms 
 | Deployment Cost                                | Deployment Size |        |        |         |         |
 | 0                                              | 0               |        |        |         |         |
 | Function Name                                  | min             | avg    | median | max     | # calls |
-| HATS                                           | 271             | 271    | 271    | 271     | 512     |
-| addSignerHats                                  | 21690           | 276233 | 70782  | 2270242 | 259     |
-| checkAfterExecution                            | 2590            | 22282  | 22745  | 35522   | 11      |
-| checkTransaction                               | 3764            | 105865 | 117190 | 144200  | 19      |
-| claimSigner                                    | 51953           | 72189  | 51953  | 169695  | 352     |
-| claimSignerFor                                 | 2595            | 63345  | 48859  | 121037  | 6       |
-| claimableFor                                   | 378             | 383    | 378    | 2378    | 772     |
-| detachHSG                                      | 21430           | 37931  | 23556  | 68807   | 3       |
-| implementation                                 | 436             | 436    | 436    | 436     | 512     |
-| lock                                           | 27360           | 27360  | 27360  | 27360   | 6       |
-| locked                                         | 410             | 410    | 410    | 410     | 512     |
-| migrateToNewHSG                                | 21548           | 53400  | 23674  | 114980  | 3       |
-| minThreshold                                   | 384             | 395    | 384    | 2384    | 516     |
-| ownerHat                                       | 385             | 385    | 385    | 385     | 512     |
-| reconcileSignerCount                           | 69988           | 80974  | 72157  | 109597  | 4       |
-| removeSigner                                   | 21690           | 76176  | 86787  | 121741  | 8       |
-| safe                                           | 404             | 404    | 404    | 404     | 833     |
-| setClaimableFor                                | 21549           | 26438  | 27793  | 27793   | 264     |
-| setMinThreshold                                | 21485           | 25665  | 24683  | 31811   | 4       |
-| setTargetThreshold                             | 21508           | 72924  | 58754  | 131643  | 11      |
-| supportsInterface                              | 399             | 399    | 399    | 399     | 322     |
-| targetThreshold                                | 361             | 372    | 361    | 2361    | 519     |
-| validSignerCount                               | 5654            | 16271  | 14629  | 29654   | 23      |
-| validSignerHats                                | 488             | 488    | 488    | 488     | 2560    |
-| version                                        | 1296            | 2358   | 3296   | 3296    | 1092    |
+| HATS                                           | 316             | 316    | 316    | 316     | 512     |
+| addSignerHats                                  | 23872           | 308865 | 70845  | 2270596 | 258     |
+| checkAfterExecution                            | 2571            | 20981  | 23945  | 30588   | 15      |
+| checkTransaction                               | 3983            | 103393 | 114651 | 135123  | 22      |
+| claimSigner                                    | 118447          | 141475 | 131950 | 219377  | 1695    |
+| claimSignerFor                                 | 58662           | 89680  | 89680  | 120698  | 2       |
+| claimSignersFor                                | 5062            | 312070 | 262035 | 951286  | 1024    |
+| claimableFor                                   | 378             | 378    | 378    | 378     | 768     |
+| claimedSignerHats                              | 612             | 612    | 612    | 612     | 2       |
+| detachHSG                                      | 68820           | 68820  | 68820  | 68820   | 1       |
+| disableDelegatecallTarget                      | 30190           | 30190  | 30190  | 30190   | 1       |
+| disableModule                                  | 35477           | 35477  | 35477  | 35477   | 1       |
+| enableDelegatecallTarget                       | 47269           | 47269  | 47269  | 47269   | 2       |
+| enableModule                                   | 52451           | 52451  | 52451  | 52451   | 6       |
+| enabledDelegatecallTargets                     | 592             | 592    | 592    | 592     | 1538    |
+| execTransactionFromModule                      | 24963           | 40694  | 40694  | 56425   | 2       |
+| execTransactionFromModuleReturnData            | 26005           | 41736  | 41736  | 57467   | 2       |
+| getGuard                                       | 419             | 419    | 419    | 419     | 515     |
+| getModulesPaginated                            | 2903            | 2903   | 2903   | 2903    | 512     |
+| implementation                                 | 414             | 414    | 414    | 414     | 512     |
+| isModuleEnabled                                | 664             | 664    | 664    | 664     | 3       |
+| isValidSigner                                  | 4183            | 4183   | 4183   | 4183    | 1346    |
+| locked                                         | 388             | 388    | 388    | 388     | 512     |
+| migrateToNewHSG                                | 115614          | 305230 | 297218 | 466976  | 257     |
+| minThreshold                                   | 385             | 392    | 385    | 2385    | 515     |
+| ownerHat                                       | 363             | 363    | 363    | 363     | 513     |
+| removeSigner                                   | 21690           | 75597  | 89744  | 124698  | 7       |
+| safe                                           | 404             | 404    | 404    | 404     | 834     |
+| setClaimableFor                                | 25085           | 27611  | 27885  | 27885   | 1282    |
+| setGuard                                       | 27092           | 42538  | 50262  | 50262   | 3       |
+| setMinThreshold                                | 23650           | 27104  | 25803  | 31859   | 3       |
+| setOwnerHat                                    | 27655           | 27655  | 27655  | 27655   | 1       |
+| setTargetThreshold                             | 23651           | 78092  | 61263  | 131676  | 10      |
+| supportsInterface                              | 444             | 444    | 444    | 444     | 579     |
+| targetThreshold                                | 384             | 395    | 384    | 2384    | 519     |
+| validSignerCount                               | 5606            | 23470  | 20548  | 56500   | 1296    |
+| validSignerHats                                | 551             | 551    | 551    | 551     | 2560    |
+
+
+| test/mocks/TestGuard.sol:TestGuard contract |                 |     |        |     |         |
+|---------------------------------------------|-----------------|-----|--------|-----|---------|
+| Deployment Cost                             | Deployment Size |     |        |     |         |
+| 596903                                      | 2780            |     |        |     |         |
+| Function Name                               | min             | avg | median | max | # calls |
+| supportsInterface                           | 353             | 353 | 353    | 353 | 514     |
 
 
 
 
-Ran 15 test suites in 957.57ms (6.95s CPU time): 68 tests passed, 0 failed, 0 skipped (68 total tests)
+Ran 25 test suites in 115.86s (394.07s CPU time): 68 tests passed, 0 failed, 0 skipped (68 total tests)

--- a/gasreport.ansi
+++ b/gasreport.ansi
@@ -1,170 +1,172 @@
-No files changed, compilation skipped
+Compiling 56 files with Solc 0.8.28
+Solc 0.8.28 finished in 9.85s
+Compiler run successful!
 
 Ran 1 test for test/HatsSignerGate.t.sol:EnablingHSGModules
-[PASS] test_happy() (gas: 92509)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.00s (92.27ms CPU time)
-
-Ran 2 tests for test/HatsSignerGate.t.sol:GuardFunctionAuth
-[PASS] testCannotCallCheckAfterExecutionFromNonSafe() (gas: 34638)
-[PASS] testCannotCallCheckTransactionFromNonSafe() (gas: 38328)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.14s (272.94ms CPU time)
-
-Ran 1 test for test/HatsSignerGate.t.sol:ClaimingSigners
-[PASS] test_happy() (gas: 259711)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.14s (260.72ms CPU time)
-
-Ran 1 test for test/HatsSignerGate.t.sol:HSGGuarding
-[PASS] test_executed() (gas: 468016)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.38s (87.23ms CPU time)
-
-Ran 2 tests for test/HatsSignerGate.t.sol:ClaimingSignerFor
-[PASS] test_happy() (gas: 319686)
-[PASS] test_happy_alreadyOwnerNotRegistered() (gas: 344434)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.55s (663.62ms CPU time)
-
-Ran 2 tests for test/HatsSignerGate.t.sol:ExecutingFromModuleReturnDataViaHSG
-[PASS] test_happy_executionFailure() (gas: 67370)
-[PASS] test_happy_executionSuccess() (gas: 104555)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.12s (163.05ms CPU time)
-
-Ran 1 test for test/HatsSignerGate.t.sol:SettingOwnerHat
-[PASS] test_happy() (gas: 65640)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.64s (79.55ms CPU time)
-
-Ran 2 tests for test/HatsSignerGate.t.sol:SettingHSGGuard
-[PASS] test_happy() (gas: 90318)
-[PASS] test_removeGuard() (gas: 64437)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.18s (257.85ms CPU time)
-
-Ran 2 tests for test/HatsSignerGate.t.sol:ExecutingFromModuleViaHSG
-[PASS] test_happy_executionFailure() (gas: 65811)
-[PASS] test_happy_executionSuccess() (gas: 102996)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 1.83s (175.22ms CPU time)
-
-Ran 7 tests for test/HatsSignerGate.t.sol:ConstrainingSigners
-[PASS] testCannotDecreaseThreshold() (gas: 1184890)
-[PASS] testCannotDisableGuard() (gas: 908081)
-[PASS] testCannotDisableModule() (gas: 932190)
-[PASS] testCannotIncreaseThreshold() (gas: 1184888)
-[PASS] testSignersCannotAddOwners() (gas: 1224040)
-[PASS] testSignersCannotRemoveOwners() (gas: 1193787)
-[PASS] testSignersCannotSwapOwners() (gas: 1225292)
-Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 6.06s (4.18s CPU time)
-
-Ran 3 tests for test/HatsSignerGate.t.sol:SettingMinThreshold
-[PASS] testNonOwnerCannotSetMinThreshold() (gas: 63889)
-[PASS] testSetInvalidMinThreshold() (gas: 60185)
-[PASS] testSetMinThreshold() (gas: 152261)
-Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 2.09s (376.16ms CPU time)
+[PASS] test_happy() (gas: 92382)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.51s (100.60ms CPU time)
 
 Ran 1 test for test/HatsSignerGate.t.sol:DisablingDelegatecallTargets
-[PASS] test_happy() (gas: 60799)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.04s (96.26ms CPU time)
+[PASS] test_happy() (gas: 60671)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.65s (187.04ms CPU time)
 
-Ran 1 test for test/HatsSignerGate.t.sol:EnablingDelegatecallTargets
-[PASS] test_happy() (gas: 87475)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.78s (82.45ms CPU time)
+Ran 1 test for test/HatsSignerGate.t.sol:ClaimingSigners
+[PASS] test_happy() (gas: 259360)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.65s (246.92ms CPU time)
 
-Ran 4 tests for test/HatsSignerGate.t.sol:SettingTargetThreshold
-[PASS] testNonOwnerHatWearerCannotSetTargetThreshold() (gas: 76505)
-[PASS] testSetTargetThreshold() (gas: 346376)
-[PASS] testSetTargetThreshold3of4() (gas: 1142955)
-[PASS] testSetTargetThreshold4of4() (gas: 1142940)
-Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 4.82s (1.96s CPU time)
-
-Ran 7 tests for test/HatsSignerGate.t.sol:ExecutingTransactions
-[PASS] testExecByLessThanMinThresholdReverts() (gas: 900799)
-[PASS] testExecTxByHatWearers() (gas: 1286917)
-[PASS] testExecTxByNonHatWearersReverts() (gas: 1280923)
-[PASS] testExecTxByTooFewOwnersReverts() (gas: 519432)
-[PASS] test_Multi_ExecTxByHatWearers() (gas: 1326427)
-[PASS] test_Multi_ExecTxByNonHatWearersReverts() (gas: 1322603)
-[PASS] test_happy_delegateCall() (gas: 1290504)
-Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 9.45s (4.33s CPU time)
-
-Ran 1 test for test/HatsSignerGate.t.sol:DetachingHSG
-[PASS] test_happy() (gas: 92373)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.71s (79.09ms CPU time)
-
-Ran 4 tests for test/HatsSignerGate.t.sol:AddingSigners
-[PASS] testAddSingleSigner() (gas: 267798)
-[PASS] testAddThreeSigners() (gas: 767436)
-[PASS] test_Multi_AddSingleSigner() (gas: 275773)
-[PASS] test_Multi_AddTwoSigners_DifferentHats() (gas: 530748)
-Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 9.45s (1.29s CPU time)
+Ran 2 tests for test/HatsSignerGate.t.sol:SettingHSGGuard
+[PASS] test_happy() (gas: 90189)
+[PASS] test_removeGuard() (gas: 64311)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.73s (327.82ms CPU time)
 
 Ran 1 test for test/HatsSignerGate.t.sol:DisablingHSGModules
-[PASS] test_happy() (gas: 66099)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.96s (66.81ms CPU time)
+[PASS] test_happy() (gas: 65971)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.74s (92.87ms CPU time)
+
+Ran 1 test for test/HatsSignerGate.t.sol:EnablingDelegatecallTargets
+[PASS] test_happy() (gas: 87349)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.04s (90.48ms CPU time)
+
+Ran 1 test for test/HatsSignerGate.t.sol:SettingOwnerHat
+[PASS] test_happy() (gas: 65519)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.88s (95.92ms CPU time)
+
+Ran 3 tests for test/HatsSignerGate.t.sol:SettingMinThreshold
+[PASS] testNonOwnerCannotSetMinThreshold() (gas: 63875)
+[PASS] testSetInvalidMinThreshold() (gas: 60175)
+[PASS] testSetMinThreshold() (gas: 152228)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 2.34s (392.20ms CPU time)
+
+Ran 2 tests for test/HatsSignerGate.t.sol:ExecutingFromModuleReturnDataViaHSG
+[PASS] test_happy_executionFailure() (gas: 67093)
+[PASS] test_happy_executionSuccess() (gas: 104380)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.58s (165.37ms CPU time)
+
+Ran 7 tests for test/HatsSignerGate.t.sol:ConstrainingSigners
+[PASS] testCannotDecreaseThreshold() (gas: 1138734)
+[PASS] testCannotDisableGuard() (gas: 862154)
+[PASS] testCannotDisableModule() (gas: 886216)
+[PASS] testCannotIncreaseThreshold() (gas: 1138732)
+[PASS] testSignersCannotAddOwners() (gas: 1177687)
+[PASS] testSignersCannotRemoveOwners() (gas: 1147242)
+[PASS] testSignersCannotSwapOwners() (gas: 1178745)
+Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 6.77s (4.42s CPU time)
+
+Ran 1 test for test/HatsSignerGate.t.sol:DetachingHSG
+[PASS] test_happy() (gas: 91598)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.91s (89.09ms CPU time)
 
 Ran 6 tests for test/HatsSignerGate.t.sol:RemovingSigners
-[PASS] testCanRemoveInvalidSigner1() (gas: 395503)
-[PASS] testCanRemoveInvalidSignerWhenMultipleSigners() (gas: 634831)
-[PASS] testCannotRemoveValidSigner() (gas: 315471)
-[PASS] testValidSignerCanClaimAfterPrevRemoved() (gas: 617964)
-[PASS] test_Multi_CanRemoveInvalidSigner1() (gas: 406795)
-[PASS] test_Multi_CannotRemoveValidSigner() (gas: 326669)
-Suite result: ok. 6 passed; 0 failed; 0 skipped; finished in 5.74s (2.36s CPU time)
+[PASS] testCanRemoveInvalidSigner1() (gas: 394799)
+[PASS] testCanRemoveInvalidSignerWhenMultipleSigners() (gas: 633859)
+[PASS] testCannotRemoveValidSigner() (gas: 314920)
+[PASS] testValidSignerCanClaimAfterPrevRemoved() (gas: 616922)
+[PASS] test_Multi_CanRemoveInvalidSigner1() (gas: 406095)
+[PASS] test_Multi_CannotRemoveValidSigner() (gas: 326114)
+Suite result: ok. 6 passed; 0 failed; 0 skipped; finished in 4.42s (2.43s CPU time)
+
+Ran 7 tests for test/HatsSignerGate.t.sol:ExecutingTransactions
+[PASS] testExecByLessThanMinThresholdReverts() (gas: 899010)
+[PASS] testExecTxByHatWearers() (gas: 1280454)
+[PASS] testExecTxByNonHatWearersReverts() (gas: 1278593)
+[PASS] testExecTxByTooFewOwnersReverts() (gas: 518330)
+[PASS] test_Multi_ExecTxByHatWearers() (gas: 1319956)
+[PASS] test_Multi_ExecTxByNonHatWearersReverts() (gas: 1320262)
+[PASS] test_happy_delegateCall() (gas: 1309501)
+Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 7.27s (4.85s CPU time)
+
+Ran 2 tests for test/HatsSignerGate.t.sol:ExecutingFromModuleViaHSG
+[PASS] test_happy_executionFailure() (gas: 65676)
+[PASS] test_happy_executionSuccess() (gas: 102963)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.18s (273.13ms CPU time)
+
+Ran 2 tests for test/HatsSignerGate.t.sol:GuardFunctionAuth
+[PASS] testCannotCallCheckAfterExecutionFromNonSafe() (gas: 34629)
+[PASS] testCannotCallCheckTransactionFromNonSafe() (gas: 38301)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.23s (197.47ms CPU time)
+
+Ran 1 test for test/HatsSignerGate.t.sol:HSGGuarding
+[PASS] test_executed() (gas: 462784)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.15s (74.16ms CPU time)
 
 Ran 8 tests for test/HatsSignerGate.attacks.t.sol:AttacksScenarios
-[PASS] testAttackerCannotExploitSigHandlingDifferences() (gas: 1706567)
-[PASS] testCanClaimToReplaceInvalidSignerAtMaxSigner() (gas: 1607255)
-[PASS] testRemoveSignerCorrectlyUpdates() (gas: 1569387)
-[PASS] testSetTargetThresholdUpdatesThresholdCorrectly() (gas: 1544580)
-[PASS] testSetTargetTresholdCannotSetBelowMinThreshold() (gas: 72346)
-[PASS] testSignersCannotAddNewModules() (gas: 948988)
-[PASS] testSignersCannotReenterCheckTransactionToAddOwners() (gas: 1396072)
-[PASS] testTargetSigAttackFails() (gas: 1966784)
-Suite result: ok. 8 passed; 0 failed; 0 skipped; finished in 9.50s (7.49s CPU time)
+[PASS] testAttackerCannotExploitSigHandlingDifferences() (gas: 1701566)
+[PASS] testCanClaimToReplaceInvalidSignerAtMaxSigner() (gas: 1605408)
+[PASS] testRemoveSignerCorrectlyUpdates() (gas: 1567250)
+[PASS] testSetTargetThresholdUpdatesThresholdCorrectly() (gas: 1542809)
+[PASS] testSetTargetTresholdCannotSetBelowMinThreshold() (gas: 72112)
+[PASS] testSignersCannotAddNewModules() (gas: 903206)
+[PASS] testSignersCannotReenterCheckTransactionToAddOwners() (gas: 1340076)
+[PASS] testTargetSigAttackFails() (gas: 1964524)
+Suite result: ok. 8 passed; 0 failed; 0 skipped; finished in 9.51s (8.07s CPU time)
+
+Ran 4 tests for test/HatsSignerGate.t.sol:AddingSigners
+[PASS] testAddSingleSigner() (gas: 267433)
+[PASS] testAddThreeSigners() (gas: 766517)
+[PASS] test_Multi_AddSingleSigner() (gas: 275409)
+[PASS] test_Multi_AddTwoSigners_DifferentHats() (gas: 530103)
+Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 2.12s (1.20s CPU time)
+
+Ran 4 tests for test/HatsSignerGate.t.sol:SettingTargetThreshold
+[PASS] testNonOwnerHatWearerCannotSetTargetThreshold() (gas: 76489)
+[PASS] testSetTargetThreshold() (gas: 346012)
+[PASS] testSetTargetThreshold3of4() (gas: 1141589)
+[PASS] testSetTargetThreshold4of4() (gas: 1141574)
+Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 5.57s (2.21s CPU time)
 
 Ran 3 tests for test/HatsSignerGate.t.sol:AddingSignerHats
-[PASS] test_Multi_NonOwnerCannotAddSignerHats() (gas: 58914)
-[PASS] test_Multi_OwnerCanAddSignerHats(uint256) (runs: 256, μ: 356398, ~: 108992)
-[PASS] test_Multi_OwnerCanAddSignerHats1() (gas: 85605)
-Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 18.79s (17.09s CPU time)
+[PASS] test_Multi_NonOwnerCannotAddSignerHats() (gas: 58896)
+[PASS] test_Multi_OwnerCanAddSignerHats(uint256) (runs: 256, μ: 372407, ~: 108961)
+[PASS] test_Multi_OwnerCanAddSignerHats1() (gas: 85577)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 20.43s (18.12s CPU time)
 
 Ran 1 test for test/HatsSignerGate.t.sol:SettingClaimableFor
-[PASS] test_happy(bool) (runs: 257, μ: 63970, ~: 65349)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 16.03s (14.07s CPU time)
+[PASS] test_happy(bool) (runs: 257, μ: 63846, ~: 65225)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 16.52s (14.59s CPU time)
+
+Ran 2 tests for test/HatsSignerGate.t.sol:ClaimingSignerFor
+[PASS] test_happy() (gas: 319323)
+[PASS] test_happy_alreadyOwnerNotRegistered() (gas: 344162)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 23.67s (580.62ms CPU time)
 
 Ran 2 tests for test/HatsSignerGate.t.sol:Deployment
-[PASS] test_andSafe(bool,bool) (runs: 257, μ: 2993847, ~: 2998931)
-[PASS] test_onlyHSG(bool,bool) (runs: 257, μ: 2916296, ~: 2915805)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 56.00s (99.27s CPU time)
+[PASS] test_andSafe(bool,bool) (runs: 257, μ: 2942722, ~: 2947807)
+[PASS] test_onlyHSG(bool,bool) (runs: 257, μ: 2866151, ~: 2865660)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 64.50s (108.91s CPU time)
 
 Ran 3 tests for test/HatsSignerGate.t.sol:ClaimingSignersFor
-[PASS] test_alreadyOwnerNotRegistered_happy(uint256) (runs: 257, μ: 1136806, ~: 1124784)
-[PASS] test_startingEmpty_happy(uint256) (runs: 257, μ: 1066672, ~: 1036790)
-[PASS] test_startingWith1Signer_happy(uint256) (runs: 257, μ: 1142520, ~: 1118935)
-Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 113.86s (269.59s CPU time)
+[PASS] test_alreadyOwnerNotRegistered_happy(uint256) (runs: 257, μ: 1126454, ~: 930870)
+[PASS] test_startingEmpty_happy(uint256) (runs: 257, μ: 1056134, ~: 853371)
+[PASS] test_startingWith1Signer_happy(uint256) (runs: 257, μ: 1131888, ~: 935133)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 99.96s (244.00s CPU time)
 
 Ran 2 tests for test/HatsSignerGate.t.sol:MigratingHSG
-[PASS] test_happy_claimableFor_signersToMigrate(uint256) (runs: 257, μ: 1849143, ~: 1712282)
-[PASS] test_happy_noSignersToMigrate() (gas: 155348)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 115.80s (113.76s CPU time)
+[PASS] test_happy_claimableFor_signersToMigrate(uint256) (runs: 257, μ: 1800323, ~: 1708508)
+[PASS] test_happy_noSignersToMigrate() (gas: 153969)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 103.31s (100.54s CPU time)
 | script/HatsSignerGate.s.sol:DeployImplementation contract |                 |         |         |         |         |
 |-----------------------------------------------------------|-----------------|---------|---------|---------|---------|
 | Deployment Cost                                           | Deployment Size |         |         |         |         |
-| 6083926                                                   | 28009           |         |         |         |         |
+| 5966005                                                   | 27424           |         |         |         |         |
 | Function Name                                             | min             | avg     | median  | max     | # calls |
-| hats                                                      | 401             | 401     | 401     | 401     | 68      |
-| prepare                                                   | 26509           | 26509   | 26509   | 26509   | 68      |
-| run                                                       | 4804724         | 4804724 | 4804724 | 4804724 | 68      |
-| safeFallbackLibrary                                       | 347             | 347     | 347     | 347     | 68      |
-| safeMultisendLibrary                                      | 346             | 346     | 346     | 346     | 68      |
-| safeProxyFactory                                          | 348             | 348     | 348     | 348     | 68      |
-| safeSingleton                                             | 369             | 369     | 369     | 369     | 68      |
-| zodiacModuleFactory                                       | 347             | 347     | 347     | 347     | 68      |
+| hats                                                      | 400             | 400     | 400     | 400     | 68      |
+| prepare                                                   | 26507           | 26507   | 26507   | 26507   | 68      |
+| run                                                       | 4700776         | 4700776 | 4700776 | 4700776 | 68      |
+| safeFallbackLibrary                                       | 346             | 346     | 346     | 346     | 68      |
+| safeMultisendLibrary                                      | 345             | 345     | 345     | 345     | 68      |
+| safeProxyFactory                                          | 347             | 347     | 347     | 347     | 68      |
+| safeSingleton                                             | 368             | 368     | 368     | 368     | 68      |
+| zodiacModuleFactory                                       | 346             | 346     | 346     | 346     | 68      |
 
 
 | script/HatsSignerGate.s.sol:DeployInstance contract |                 |        |        |        |         |
 |-----------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                     | Deployment Size |        |        |        |         |
-| 1477980                                             | 6578            |        |        |        |         |
+| 1447213                                             | 6424            |        |        |        |         |
 | Function Name                                       | min             | avg    | median | max    | # calls |
-| prepare1                                            | 254422          | 365237 | 382529 | 382769 | 580     |
-| prepare2                                            | 46044           | 48822  | 48832  | 48832  | 580     |
-| run                                                 | 514247          | 773484 | 811131 | 918666 | 580     |
+| prepare1                                            | 254403          | 365218 | 382510 | 382750 | 580     |
+| prepare2                                            | 46041           | 48819  | 48829  | 48829  | 580     |
+| run                                                 | 496118          | 754128 | 791423 | 898560 | 580     |
 
 
 | src/HatsSignerGate.sol:HatsSignerGate contract |                 |        |        |         |         |
@@ -172,53 +174,53 @@ Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 115.80s (113.76s CP
 | Deployment Cost                                | Deployment Size |        |        |         |         |
 | 0                                              | 0               |        |        |         |         |
 | Function Name                                  | min             | avg    | median | max     | # calls |
-| HATS                                           | 316             | 316    | 316    | 316     | 512     |
-| addSignerHats                                  | 23872           | 308865 | 70845  | 2270596 | 258     |
-| checkAfterExecution                            | 2571            | 20981  | 23945  | 30588   | 15      |
-| checkTransaction                               | 3983            | 103393 | 114651 | 135123  | 22      |
-| claimSigner                                    | 118447          | 141475 | 131950 | 219377  | 1695    |
-| claimSignerFor                                 | 58662           | 89680  | 89680  | 120698  | 2       |
-| claimSignersFor                                | 5062            | 312070 | 262035 | 951286  | 1024    |
-| claimableFor                                   | 378             | 378    | 378    | 378     | 768     |
-| claimedSignerHats                              | 612             | 612    | 612    | 612     | 2       |
-| detachHSG                                      | 68820           | 68820  | 68820  | 68820   | 1       |
-| disableDelegatecallTarget                      | 30190           | 30190  | 30190  | 30190   | 1       |
-| disableModule                                  | 35477           | 35477  | 35477  | 35477   | 1       |
-| enableDelegatecallTarget                       | 47269           | 47269  | 47269  | 47269   | 2       |
-| enableModule                                   | 52451           | 52451  | 52451  | 52451   | 6       |
-| enabledDelegatecallTargets                     | 592             | 592    | 592    | 592     | 1538    |
-| execTransactionFromModule                      | 24963           | 40694  | 40694  | 56425   | 2       |
-| execTransactionFromModuleReturnData            | 26005           | 41736  | 41736  | 57467   | 2       |
-| getGuard                                       | 419             | 419    | 419    | 419     | 515     |
-| getModulesPaginated                            | 2903            | 2903   | 2903   | 2903    | 512     |
-| implementation                                 | 414             | 414    | 414    | 414     | 512     |
-| isModuleEnabled                                | 664             | 664    | 664    | 664     | 3       |
-| isValidSigner                                  | 4183            | 4183   | 4183   | 4183    | 1346    |
-| locked                                         | 388             | 388    | 388    | 388     | 512     |
-| migrateToNewHSG                                | 115614          | 305230 | 297218 | 466976  | 257     |
-| minThreshold                                   | 385             | 392    | 385    | 2385    | 515     |
-| ownerHat                                       | 363             | 363    | 363    | 363     | 513     |
-| removeSigner                                   | 21690           | 75597  | 89744  | 124698  | 7       |
-| safe                                           | 404             | 404    | 404    | 404     | 834     |
-| setClaimableFor                                | 25085           | 27611  | 27885  | 27885   | 1282    |
-| setGuard                                       | 27092           | 42538  | 50262  | 50262   | 3       |
-| setMinThreshold                                | 23650           | 27104  | 25803  | 31859   | 3       |
-| setOwnerHat                                    | 27655           | 27655  | 27655  | 27655   | 1       |
-| setTargetThreshold                             | 23651           | 78092  | 61263  | 131676  | 10      |
-| supportsInterface                              | 444             | 444    | 444    | 444     | 579     |
-| targetThreshold                                | 384             | 395    | 384    | 2384    | 519     |
-| validSignerCount                               | 5606            | 23470  | 20548  | 56500   | 1296    |
-| validSignerHats                                | 551             | 551    | 551    | 551     | 2560    |
+| HATS                                           | 315             | 315    | 315    | 315     | 512     |
+| addSignerHats                                  | 23866           | 324300 | 70832  | 2270389 | 258     |
+| checkAfterExecution                            | 2568            | 20851  | 23801  | 30451   | 15      |
+| checkTransaction                               | 3965            | 74980  | 79421  | 99813   | 22      |
+| claimSigner                                    | 115623          | 140907 | 131689 | 219102  | 1657    |
+| claimSignerFor                                 | 58654           | 89513  | 89513  | 120373  | 2       |
+| claimSignersFor                                | 5052            | 308276 | 247469 | 948539  | 1024    |
+| claimableFor                                   | 377             | 377    | 377    | 377     | 768     |
+| claimedSignerHats                              | 609             | 609    | 609    | 609     | 2       |
+| detachHSG                                      | 68398           | 68398  | 68398  | 68398   | 1       |
+| disableDelegatecallTarget                      | 30185           | 30185  | 30185  | 30185   | 1       |
+| disableModule                                  | 35471           | 35471  | 35471  | 35471   | 1       |
+| enableDelegatecallTarget                       | 47265           | 47265  | 47265  | 47265   | 2       |
+| enableModule                                   | 52446           | 52446  | 52446  | 52446   | 6       |
+| enabledDelegatecallTargets                     | 589             | 589    | 589    | 589     | 1538    |
+| execTransactionFromModule                      | 24949           | 40680  | 40680  | 56411   | 2       |
+| execTransactionFromModuleReturnData            | 25901           | 41632  | 41632  | 57363   | 2       |
+| getGuard                                       | 417             | 417    | 417    | 417     | 515     |
+| getModulesPaginated                            | 2888            | 2888   | 2888   | 2888    | 512     |
+| implementation                                 | 413             | 413    | 413    | 413     | 512     |
+| isModuleEnabled                                | 660             | 660    | 660    | 660     | 3       |
+| isValidSigner                                  | 4179            | 4179   | 4179   | 4179    | 1308    |
+| locked                                         | 387             | 387    | 387    | 387     | 512     |
+| migrateToNewHSG                                | 114827          | 299369 | 296377 | 466095  | 257     |
+| minThreshold                                   | 384             | 391    | 384    | 2384    | 515     |
+| ownerHat                                       | 362             | 362    | 362    | 362     | 513     |
+| removeSigner                                   | 21686           | 75365  | 89424  | 124367  | 7       |
+| safe                                           | 403             | 403    | 403    | 403     | 834     |
+| setClaimableFor                                | 25082           | 27608  | 27882  | 27882   | 1282    |
+| setGuard                                       | 27088           | 42532  | 50254  | 50254   | 3       |
+| setMinThreshold                                | 23647           | 27101  | 25800  | 31856   | 3       |
+| setOwnerHat                                    | 27652           | 27652  | 27652  | 27652   | 1       |
+| setTargetThreshold                             | 23648           | 78006  | 61249  | 131475  | 10      |
+| supportsInterface                              | 441             | 441    | 441    | 441     | 579     |
+| targetThreshold                                | 383             | 394    | 383    | 2383    | 519     |
+| validSignerCount                               | 5595            | 23206  | 20531  | 56469   | 1296    |
+| validSignerHats                                | 548             | 548    | 548    | 548     | 2560    |
 
 
 | test/mocks/TestGuard.sol:TestGuard contract |                 |     |        |     |         |
 |---------------------------------------------|-----------------|-----|--------|-----|---------|
 | Deployment Cost                             | Deployment Size |     |        |     |         |
-| 596903                                      | 2780            |     |        |     |         |
+| 588049                                      | 2727            |     |        |     |         |
 | Function Name                               | min             | avg | median | max | # calls |
-| supportsInterface                           | 353             | 353 | 353    | 353 | 514     |
+| supportsInterface                           | 350             | 350 | 350    | 350 | 514     |
 
 
 
 
-Ran 25 test suites in 115.86s (394.07s CPU time): 68 tests passed, 0 failed, 0 skipped (68 total tests)
+Ran 25 test suites in 103.38s (394.64s CPU time): 68 tests passed, 0 failed, 0 skipped (68 total tests)

--- a/gasreport.ansi
+++ b/gasreport.ansi
@@ -1,141 +1,217 @@
-Compiling 4 files with Solc 0.8.20
-Solc 0.8.20 finished in 8.16s
-Compiler run successful!
-
-Ran 2 tests for test/HatsSignerGate.t.sol:GuardFunctionAuth
-[PASS] testCannotCallCheckAfterExecutionFromNonSafe() (gas: 34657)
-[PASS] testCannotCallCheckTransactionFromNonSafe() (gas: 38123)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 379.15ms (1.43ms CPU time)
+No files changed, compilation skipped
 
 Ran 3 tests for test/HatsSignerGate.t.sol:DetachingHSG
-[PASS] test_happy() (gas: 91086)
-[PASS] test_revert_locked() (gas: 127331)
-[PASS] test_revert_nonOwner() (gas: 73190)
-Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 380.91ms (3.86ms CPU time)
+[PASS] test_happy() (gas: 91664)
+[PASS] test_revert_locked() (gas: 107206)
+[PASS] test_revert_nonOwner() (gas: 76291)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 1.47s (198.63ms CPU time)
+
+Ran 3 tests for test/HatsSignerGate.t.sol:EnablingHSGModules
+[PASS] test_happy() (gas: 92448)
+[PASS] test_revert_locked() (gas: 95412)
+[PASS] test_revert_notOwner() (gas: 64574)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 1.59s (295.20ms CPU time)
+
+Ran 3 tests for test/HatsSignerGate.t.sol:DisablingDelegatecallTargets
+[PASS] test_happy() (gas: 60737)
+[PASS] test_revert_locked() (gas: 95331)
+[PASS] test_revert_notOwner() (gas: 64493)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 1.59s (277.02ms CPU time)
+
+Ran 3 tests for test/HatsSignerGate.t.sol:DisablingHSGModules
+[PASS] test_happy() (gas: 66037)
+[PASS] test_revert_locked() (gas: 95629)
+[PASS] test_revert_notOwner() (gas: 64791)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 1.62s (289.85ms CPU time)
+
+Ran 6 tests for test/HatsSignerGate.t.sol:ExecutingFromModuleReturnDataViaHSG
+[PASS] test_happy_executionFailure() (gas: 67138)
+[PASS] test_happy_executionSuccess() (gas: 104358)
+[PASS] test_revert_delegatecallTargetNotEnabled() (gas: 44445)
+[PASS] test_revert_moduleCannotCallSafe() (gas: 44958)
+[PASS] test_revert_notModule() (gas: 51631)
+[PASS] test_success_defaultDelegatecallTargets() (gas: 522983)
+Suite result: ok. 6 passed; 0 failed; 0 skipped; finished in 1.82s (519.22ms CPU time)
+
+Ran 6 tests for test/HatsSignerGate.t.sol:ClaimingSignerFor
+[PASS] test_happy() (gas: 319301)
+[PASS] test_happy_alreadyOwnerNotRegistered() (gas: 344140)
+[PASS] test_revert_alreadyClaimed() (gas: 371471)
+[PASS] test_revert_invalidSigner() (gas: 190504)
+[PASS] test_revert_invalidSignerHat() (gas: 231634)
+[PASS] test_revert_notClaimableFor() (gas: 281558)
+Suite result: ok. 6 passed; 0 failed; 0 skipped; finished in 2.31s (1.01s CPU time)
+
+Ran 3 tests for test/HatsSignerGate.t.sol:EnablingDelegatecallTargets
+[PASS] test_happy() (gas: 87415)
+[PASS] test_revert_locked() (gas: 95297)
+[PASS] test_revert_notOwner() (gas: 64459)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 1.45s (200.75ms CPU time)
+
+Ran 4 tests for test/HatsSignerGate.t.sol:SettingHSGGuard
+[PASS] test_happy() (gas: 90108)
+[PASS] test_removeGuard() (gas: 64378)
+[PASS] test_revert_locked() (gas: 95127)
+[PASS] test_revert_notOwner() (gas: 64311)
+Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 1.15s (244.94ms CPU time)
+
+Ran 6 tests for test/HatsSignerGate.t.sol:ExecutingFromModuleViaHSG
+[PASS] test_happy_delegateCall() (gas: 514450)
+[PASS] test_happy_executionFailure() (gas: 65699)
+[PASS] test_happy_executionSuccess() (gas: 102941)
+[PASS] test_revert_delegatecallTargetNotEnabled() (gas: 42346)
+[PASS] test_revert_moduleCannotCallSafe() (gas: 42846)
+[PASS] test_revert_notModule() (gas: 50424)
+Suite result: ok. 6 passed; 0 failed; 0 skipped; finished in 1.72s (520.75ms CPU time)
+
+Ran 8 tests for test/HatsSignerGate.t.sol:ConstrainingSigners
+[PASS] testCannotDecreaseThreshold() (gas: 1138734)
+[PASS] testCannotDisableGuard() (gas: 862154)
+[PASS] testCannotDisableModule() (gas: 886216)
+[PASS] testCannotIncreaseThreshold() (gas: 1138732)
+[PASS] testSignersCannotAddOwners() (gas: 1177687)
+[PASS] testSignersCannotRemoveOwners() (gas: 1147242)
+[PASS] testSignersCannotSwapOwners() (gas: 1178723)
+[PASS] test_revert_delegatecallTargetNotEnabled() (gas: 785273)
+Suite result: ok. 8 passed; 0 failed; 0 skipped; finished in 3.56s (2.53s CPU time)
+
+Ran 3 tests for test/HatsSignerGate.t.sol:SettingOwnerHat
+[PASS] test_happy() (gas: 65585)
+[PASS] test_revert_locked() (gas: 94809)
+[PASS] test_revert_notOwner() (gas: 65971)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 1.49s (252.26ms CPU time)
+
+Ran 8 tests for test/HatsSignerGate.t.sol:ExecutingTransactions
+[PASS] testExecByLessThanMinThresholdReverts() (gas: 898988)
+[PASS] testExecTxByHatWearers() (gas: 1280454)
+[PASS] testExecTxByNonHatWearersReverts() (gas: 1278593)
+[PASS] testExecTxByTooFewOwnersReverts() (gas: 518330)
+[PASS] test_Multi_ExecTxByHatWearers() (gas: 1319956)
+[PASS] test_Multi_ExecTxByNonHatWearersReverts() (gas: 1320285)
+[PASS] test_happy_delegateCall() (gas: 1926566)
+[PASS] test_revert_delegateCallTargetNotEnabled() (gas: 790920)
+Suite result: ok. 8 passed; 0 failed; 0 skipped; finished in 4.16s (2.87s CPU time)
 
 Ran 4 tests for test/HatsSignerGate.t.sol:SettingMinThreshold
-[PASS] testNonOwnerCannotSetMinThreshold() (gas: 61429)
-[PASS] testSetInvalidMinThreshold() (gas: 60137)
-[PASS] testSetMinThreshold() (gas: 151859)
-[PASS] test_revert_locked() (gas: 109965)
-Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 382.48ms (6.66ms CPU time)
+[PASS] testNonOwnerCannotSetMinThreshold() (gas: 63875)
+[PASS] testSetInvalidMinThreshold() (gas: 60175)
+[PASS] testSetMinThreshold() (gas: 152292)
+[PASS] test_revert_locked() (gas: 88872)
+Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 1.57s (360.74ms CPU time)
 
-Ran 3 tests for test/HatsSignerGate.t.sol:MigratingHSG
-[PASS] test_happy() (gas: 151577)
-[PASS] test_revert_locked() (gas: 112373)
-[PASS] test_revert_nonOwner() (gas: 58232)
-Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 382.72ms (3.13ms CPU time)
+Ran 2 tests for test/HatsSignerGate.t.sol:GuardFunctionAuth
+[PASS] testCannotCallCheckAfterExecutionFromNonSafe() (gas: 34607)
+[PASS] testCannotCallCheckTransactionFromNonSafe() (gas: 38279)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 1.04s (93.78ms CPU time)
 
-Ran 5 tests for test/HatsSignerGate.t.sol:ClaimingSignerFor
-[PASS] test_happy() (gas: 319243)
-[PASS] test_revert_alreadyClaimed() (gas: 404040)
-[PASS] test_revert_invalidSigner() (gas: 225401)
-[PASS] test_revert_invalidSignerHat() (gas: 271466)
-[PASS] test_revert_notClaimableFor() (gas: 283302)
-Suite result: ok. 5 passed; 0 failed; 0 skipped; finished in 510.39ms (135.20ms CPU time)
+Ran 3 tests for test/HatsSignerGate.t.sol:HSGGuarding
+[PASS] test_executed() (gas: 462762)
+[PASS] test_revert_checkAfterExecution() (gas: 487694)
+[PASS] test_revert_checkTransaction() (gas: 332912)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 1.27s (195.37ms CPU time)
 
 Ran 4 tests for test/HatsSignerGate.t.sol:AddingSigners
-[PASS] testAddSingleSigner() (gas: 266837)
-[PASS] testAddThreeSigners() (gas: 766843)
-[PASS] test_Multi_AddSingleSigner() (gas: 275167)
-[PASS] test_Multi_AddTwoSigners_DifferentHats() (gas: 530107)
-Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 514.00ms (260.46ms CPU time)
+[PASS] testAddSingleSigner() (gas: 267433)
+[PASS] testAddThreeSigners() (gas: 766517)
+[PASS] test_Multi_AddSingleSigner() (gas: 275473)
+[PASS] test_Multi_AddTwoSigners_DifferentHats() (gas: 530103)
+Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 1.95s (700.14ms CPU time)
 
-Ran 7 tests for test/HatsSignerGate.t.sol:RemovingSigners
-[PASS] testCanRemoveInvalidSigner1() (gas: 399279)
-[PASS] testCanRemoveInvalidSignerAfterReconcile2Signers() (gas: 745240)
-[PASS] testCanRemoveInvalidSignerAfterReconcile3PLusSigners() (gas: 1015577)
-[PASS] testCanRemoveInvalidSignerWhenMultipleSigners() (gas: 640866)
-[PASS] testCannotRemoveValidSigner() (gas: 324512)
-[PASS] test_Multi_CanRemoveInvalidSigner1() (gas: 412477)
-[PASS] test_Multi_CannotRemoveValidSigner() (gas: 335756)
-Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 517.54ms (141.55ms CPU time)
-
-Ran 6 tests for test/HatsSignerGate.t.sol:ExecutingTransactions
-[PASS] testExecByLessThanMinThresholdReverts() (gas: 876991)
-[PASS] testExecTxByHatWearers() (gas: 1295054)
-[PASS] testExecTxByNonHatWearersReverts() (gas: 1294922)
-[PASS] testExecTxByTooFewOwnersReverts() (gas: 497379)
-[PASS] test_Multi_ExecTxByHatWearers() (gas: 1334609)
-[PASS] test_Multi_ExecTxByNonHatWearersReverts() (gas: 1336647)
-Suite result: ok. 6 passed; 0 failed; 0 skipped; finished in 520.71ms (275.40ms CPU time)
-
-Ran 7 tests for test/HatsSignerGate.t.sol:ConstrainingSigners
-[PASS] testCannotDecreaseThreshold() (gas: 1189360)
-[PASS] testCannotDisableGuard() (gas: 911623)
-[PASS] testCannotDisableModule() (gas: 939594)
-[PASS] testCannotIncreaseThreshold() (gas: 1189358)
-[PASS] testSignersCannotAddOwners() (gas: 1233420)
-[PASS] testSignersCannotRemoveOwners() (gas: 1201906)
-[PASS] testSignersCannotSwapOwners() (gas: 1233969)
-Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 520.71ms (152.41ms CPU time)
-
-Ran 8 tests for test/HatsSignerGate.attacks.t.sol:AttacksScenarios
-[PASS] testAttackerCannotExploitSigHandlingDifferences() (gas: 1723905)
-[PASS] testCanClaimToReplaceInvalidSignerAtMaxSigner() (gas: 1608698)
-[PASS] testRemoveSignerCorrectlyUpdates() (gas: 1575859)
-[PASS] testSetTargetThresholdUpdatesThresholdCorrectly() (gas: 1545610)
-[PASS] testSetTargetTresholdCannotSetBelowMinThreshold() (gas: 70984)
-[PASS] testSignersCannotAddNewModules() (gas: 956462)
-[PASS] testSignersCannotReenterCheckTransactionToAddOwners() (gas: 1400594)
-[PASS] testTargetSigAttackFails() (gas: 2294663)
-Suite result: ok. 8 passed; 0 failed; 0 skipped; finished in 520.69ms (161.47ms CPU time)
+Ran 6 tests for test/HatsSignerGate.t.sol:RemovingSigners
+[PASS] testCanRemoveInvalidSigner1() (gas: 394799)
+[PASS] testCanRemoveInvalidSignerWhenMultipleSigners() (gas: 633837)
+[PASS] testCannotRemoveValidSigner() (gas: 314920)
+[PASS] testValidSignerCanClaimAfterPrevRemoved() (gas: 616900)
+[PASS] test_Multi_CanRemoveInvalidSigner1() (gas: 406073)
+[PASS] test_Multi_CannotRemoveValidSigner() (gas: 326092)
+Suite result: ok. 6 passed; 0 failed; 0 skipped; finished in 2.21s (1.29s CPU time)
 
 Ran 4 tests for test/HatsSignerGate.t.sol:AddingSignerHats
-[PASS] test_Multi_NonOwnerCannotAddSignerHats() (gas: 56734)
-[PASS] test_Multi_OwnerCanAddSignerHats(uint256) (runs: 259, μ: 321587, ~: 109031)
-[PASS] test_Multi_OwnerCanAddSignerHats1() (gas: 85590)
-[PASS] test_revert_locked() (gas: 110971)
-Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 585.56ms (209.84ms CPU time)
-
-Ran 4 tests for test/HatsSignerGate.t.sol:ClaimingSigners
-[PASS] test_happy() (gas: 259015)
-[PASS] test_revert_alreadyClaimed() (gas: 594831)
-[PASS] test_revert_invalidSigner() (gas: 128783)
-[PASS] test_revert_multi_invalidSigner(uint256) (runs: 257, μ: 131629, ~: 131629)
-Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 682.87ms (306.61ms CPU time)
-
-Ran 5 tests for test/HatsSignerGate.t.sol:SettingTargetThreshold
-[PASS] testNonOwnerHatWearerCannotSetTargetThreshold() (gas: 73646)
-[PASS] testSetTargetThreshold() (gas: 345982)
-[PASS] testSetTargetThreshold3of4() (gas: 1143634)
-[PASS] testSetTargetThreshold4of4() (gas: 1143705)
-[PASS] test_revert_locked() (gas: 109987)
-Suite result: ok. 5 passed; 0 failed; 0 skipped; finished in 319.08ms (7.50ms CPU time)
+[PASS] test_Multi_NonOwnerCannotAddSignerHats() (gas: 58896)
+[PASS] test_Multi_OwnerCanAddSignerHats(uint256) (runs: 256, μ: 351144, ~: 108961)
+[PASS] test_Multi_OwnerCanAddSignerHats1() (gas: 85577)
+[PASS] test_revert_locked() (gas: 89885)
+Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 15.32s (14.14s CPU time)
 
 Ran 3 tests for test/HatsSignerGate.t.sol:SettingClaimableFor
-[PASS] test_happy(bool) (runs: 259, μ: 63227, ~: 64595)
-[PASS] test_revert_locked() (gas: 119322)
-[PASS] test_revert_nonOwner() (gas: 65203)
-Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 209.74ms (26.98ms CPU time)
+[PASS] test_happy(bool) (runs: 256, μ: 63884, ~: 65269)
+[PASS] test_revert_locked() (gas: 96353)
+[PASS] test_revert_nonOwner() (gas: 65460)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 14.67s (13.90s CPU time)
+
+Ran 4 tests for test/HatsSignerGate.t.sol:ClaimingSigners
+[PASS] test_happy() (gas: 259338)
+[PASS] test_revert_alreadyClaimed() (gas: 548757)
+[PASS] test_revert_invalidSigner() (gas: 98332)
+[PASS] test_revert_multi_invalidSigner(uint256) (runs: 256, μ: 101149, ~: 101149)
+Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 29.25s (28.11s CPU time)
 
 Ran 3 tests for test/HatsSignerGate.t.sol:Deployment
-[PASS] test_andSafe(bool,bool) (runs: 259, μ: 2473691, ~: 2478879)
-[PASS] test_onlyHSG(bool,bool) (runs: 259, μ: 2397306, ~: 2397783)
-[PASS] test_revert_reinitializeImplementation() (gas: 57512)
-Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 520.56ms (350.15ms CPU time)
+[PASS] test_andSafe(bool,bool) (runs: 256, μ: 3026502, ~: 3031610)
+[PASS] test_onlyHSG(bool,bool) (runs: 256, μ: 2949893, ~: 2949404)
+[PASS] test_revert_reinitializeImplementation() (gas: 56660)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 67.25s (119.32s CPU time)
+
+Ran 5 tests for test/HatsSignerGate.t.sol:SettingTargetThreshold
+[PASS] testNonOwnerHatWearerCannotSetTargetThreshold() (gas: 76467)
+[PASS] testSetTargetThreshold() (gas: 345990)
+[PASS] testSetTargetThreshold3of4() (gas: 1141634)
+[PASS] testSetTargetThreshold4of4() (gas: 1141638)
+[PASS] test_revert_locked() (gas: 88872)
+Suite result: ok. 5 passed; 0 failed; 0 skipped; finished in 111.15s (1.16s CPU time)
+
+Ran 5 tests for test/HatsSignerGate.t.sol:MigratingHSG
+[PASS] test_happy_claimableFor_signersToMigrate(uint256) (runs: 256, μ: 1728022, ~: 1392903)
+[PASS] test_happy_noSignersToMigrate() (gas: 154013)
+[PASS] test_revert_locked() (gas: 92835)
+[PASS] test_revert_nonOwner() (gas: 61964)
+[PASS] test_revert_notClaimableFor_signersToMigrate(uint256) (runs: 256, μ: 1510509, ~: 1206562)
+Suite result: ok. 5 passed; 0 failed; 0 skipped; finished in 116.86s (224.92s CPU time)
+
+Ran 8 tests for test/HatsSignerGate.t.sol:ClaimingSignersFor
+[PASS] test_alreadyOwnerNotRegistered_happy(uint256) (runs: 256, μ: 1134017, ~: 930870)
+[PASS] test_revert_alreadyClaimed(uint256,uint256) (runs: 256, μ: 1019055, ~: 995946)
+[PASS] test_revert_invalidArrayLength(uint256) (runs: 256, μ: 569566, ~: 474870)
+[PASS] test_revert_invalidSigner(uint256,uint256) (runs: 256, μ: 797873, ~: 800788)
+[PASS] test_revert_invalidSignerHat(uint256) (runs: 256, μ: 573869, ~: 479333)
+[PASS] test_revert_notClaimableFor(uint256) (runs: 256, μ: 653064, ~: 558434)
+[PASS] test_startingEmpty_happy(uint256) (runs: 256, μ: 1063331, ~: 853371)
+[PASS] test_startingWith1Signer_happy(uint256) (runs: 256, μ: 1139529, ~: 935133)
+Suite result: ok. 8 passed; 0 failed; 0 skipped; finished in 114.12s (730.39s CPU time)
+
+Ran 8 tests for test/HatsSignerGate.attacks.t.sol:AttacksScenarios
+[PASS] testAttackerCannotExploitSigHandlingDifferences() (gas: 1701566)
+[PASS] testCanClaimToReplaceInvalidSignerAtMaxSigner() (gas: 1605472)
+[PASS] testRemoveSignerCorrectlyUpdates() (gas: 1567250)
+[PASS] testSetTargetThresholdUpdatesThresholdCorrectly() (gas: 1542809)
+[PASS] testSetTargetTresholdCannotSetBelowMinThreshold() (gas: 72112)
+[PASS] testSignersCannotAddNewModules() (gas: 903271)
+[PASS] testSignersCannotReenterCheckTransactionToAddOwners() (gas: 1337704)
+[PASS] testTargetSigAttackFails() (gas: 1964524)
+Suite result: ok. 8 passed; 0 failed; 0 skipped; finished in 117.80s (4.20s CPU time)
 | script/HatsSignerGate.s.sol:DeployImplementation contract |                 |         |         |         |         |
 |-----------------------------------------------------------|-----------------|---------|---------|---------|---------|
 | Deployment Cost                                           | Deployment Size |         |         |         |         |
-| 5574775                                                   | 25877           |         |         |         |         |
+| 5969019                                                   | 27435           |         |         |         |         |
 | Function Name                                             | min             | avg     | median  | max     | # calls |
-| hats                                                      | 401             | 401     | 401     | 401     | 68      |
-| prepare                                                   | 32744           | 32744   | 32744   | 32744   | 68      |
-| run                                                       | 4035840         | 4035840 | 4035840 | 4035840 | 68      |
-| safeFallbackLibrary                                       | 347             | 347     | 347     | 347     | 68      |
-| safeMultisendLibrary                                      | 346             | 346     | 346     | 346     | 68      |
-| safeProxyFactory                                          | 348             | 348     | 348     | 348     | 68      |
-| safeSingleton                                             | 391             | 391     | 391     | 391     | 68      |
-| zodiacModuleFactory                                       | 369             | 369     | 369     | 369     | 68      |
+| hats                                                      | 400             | 400     | 400     | 400     | 115     |
+| prepare                                                   | 26507           | 26507   | 26507   | 26507   | 115     |
+| run                                                       | 4702982         | 4702982 | 4702982 | 4702982 | 115     |
+| safeFallbackLibrary                                       | 346             | 346     | 346     | 346     | 115     |
+| safeMultisendLibrary                                      | 345             | 345     | 345     | 345     | 115     |
+| safeProxyFactory                                          | 347             | 347     | 347     | 347     | 115     |
+| safeSingleton                                             | 368             | 368     | 368     | 368     | 115     |
+| zodiacModuleFactory                                       | 346             | 346     | 346     | 346     | 115     |
 
 
 | script/HatsSignerGate.s.sol:DeployInstance contract |                 |        |        |        |         |
 |-----------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                     | Deployment Size |        |        |        |         |
-| 1308948                                             | 5701            |        |        |        |         |
+| 1447213                                             | 6424            |        |        |        |         |
 | Function Name                                       | min             | avg    | median | max    | # calls |
-| prepare                                             | 276306          | 291608 | 296230 | 296470 | 580     |
-| run                                                 | 441735          | 606544 | 738761 | 739773 | 580     |
+| prepare1                                            | 254403          | 356650 | 382498 | 382750 | 629     |
+| prepare2                                            | 46041           | 48806  | 48829  | 48829  | 629     |
+| run                                                 | 566837          | 826362 | 862179 | 969316 | 629     |
 
 
 | src/HatsSignerGate.sol:HatsSignerGate contract |                 |        |        |         |         |
@@ -143,33 +219,55 @@ Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 520.56ms (350.15ms 
 | Deployment Cost                                | Deployment Size |        |        |         |         |
 | 0                                              | 0               |        |        |         |         |
 | Function Name                                  | min             | avg    | median | max     | # calls |
-| HATS                                           | 271             | 271    | 271    | 271     | 512     |
-| addSignerHats                                  | 21690           | 276233 | 70782  | 2270242 | 259     |
-| checkAfterExecution                            | 2590            | 22282  | 22745  | 35522   | 11      |
-| checkTransaction                               | 3764            | 105865 | 117190 | 144200  | 19      |
-| claimSigner                                    | 51953           | 72189  | 51953  | 169695  | 352     |
-| claimSignerFor                                 | 2595            | 63345  | 48859  | 121037  | 6       |
-| claimableFor                                   | 378             | 383    | 378    | 2378    | 772     |
-| detachHSG                                      | 21430           | 37931  | 23556  | 68807   | 3       |
-| implementation                                 | 436             | 436    | 436    | 436     | 512     |
-| lock                                           | 27360           | 27360  | 27360  | 27360   | 6       |
-| locked                                         | 410             | 410    | 410    | 410     | 512     |
-| migrateToNewHSG                                | 21548           | 53400  | 23674  | 114980  | 3       |
-| minThreshold                                   | 384             | 395    | 384    | 2384    | 516     |
-| ownerHat                                       | 385             | 385    | 385    | 385     | 512     |
-| reconcileSignerCount                           | 69988           | 80974  | 72157  | 109597  | 4       |
-| removeSigner                                   | 21690           | 76176  | 86787  | 121741  | 8       |
-| safe                                           | 404             | 404    | 404    | 404     | 833     |
-| setClaimableFor                                | 21549           | 26438  | 27793  | 27793   | 264     |
-| setMinThreshold                                | 21485           | 25665  | 24683  | 31811   | 4       |
-| setTargetThreshold                             | 21508           | 72924  | 58754  | 131643  | 11      |
-| supportsInterface                              | 399             | 399    | 399    | 399     | 322     |
-| targetThreshold                                | 361             | 372    | 361    | 2361    | 519     |
-| validSignerCount                               | 5654            | 16271  | 14629  | 29654   | 23      |
-| validSignerHats                                | 488             | 488    | 488    | 488     | 2560    |
-| version                                        | 1296            | 2358   | 3296   | 3296    | 1092    |
+| HATS                                           | 315             | 315    | 315    | 315     | 512     |
+| addSignerHats                                  | 2682            | 302658 | 70832  | 2270389 | 259     |
+| checkAfterExecution                            | 2568            | 20413  | 23801  | 30451   | 19      |
+| checkTransaction                               | 3965            | 67753  | 72966  | 99813   | 29      |
+| claimSigner                                    | 21646           | 130889 | 123599 | 219102  | 3381    |
+| claimSignerFor                                 | 2570            | 50970  | 26094  | 120373  | 7       |
+| claimSignersFor                                | 2909            | 172335 | 78604  | 948539  | 2560    |
+| claimableFor                                   | 377             | 382    | 377    | 2377    | 772     |
+| claimedSignerHats                              | 609             | 609    | 609    | 609     | 2       |
+| detachHSG                                      | 2387            | 31452  | 23571  | 68398   | 3       |
+| disableDelegatecallTarget                      | 2547            | 18821  | 23731  | 30185   | 3       |
+| disableModule                                  | 2613            | 20627  | 23797  | 35471   | 3       |
+| enableDelegatecallTarget                       | 2526            | 35882  | 47265  | 47265   | 6       |
+| enableModule                                   | 2570            | 48081  | 52446  | 52446   | 18      |
+| enabledDelegatecallTargets                     | 589             | 591    | 589    | 2589    | 3078    |
+| execTransactionFromModule                      | 2965            | 35317  | 48955  | 56411   | 11      |
+| execTransactionFromModuleReturnData            | 2950            | 36004  | 49904  | 57363   | 11      |
+| getGuard                                       | 417             | 424    | 417    | 2417    | 519     |
+| getModulesPaginated                            | 2888            | 2888   | 2888   | 2888    | 512     |
+| implementation                                 | 413             | 413    | 413    | 413     | 512     |
+| isModuleEnabled                                | 660             | 1548   | 660    | 2660    | 9       |
+| isValidSigner                                  | 4179            | 4448   | 4448   | 4718    | 2508    |
+| lock                                           | 27405           | 27405  | 27405  | 27405   | 12      |
+| locked                                         | 387             | 387    | 387    | 387     | 512     |
+| migrateToNewHSG                                | 3026            | 204674 | 119131 | 466095  | 515     |
+| minThreshold                                   | 384             | 391    | 384    | 2384    | 515     |
+| ownerHat                                       | 362             | 365    | 362    | 2362    | 515     |
+| removeSigner                                   | 21686           | 75365  | 89424  | 124367  | 7       |
+| safe                                           | 403             | 403    | 403    | 403     | 880     |
+| setClaimableFor                                | 2571            | 27746  | 27882  | 27882   | 2825    |
+| setGuard                                       | 2569            | 36346  | 50254  | 50254   | 7       |
+| setMinThreshold                                | 2463            | 20941  | 24723  | 31856   | 4       |
+| setOwnerHat                                    | 2485            | 17935  | 23669  | 27652   | 3       |
+| setTargetThreshold                             | 2464            | 71138  | 58762  | 131475  | 11      |
+| supportsInterface                              | 441             | 441    | 441    | 441     | 881     |
+| targetThreshold                                | 383             | 394    | 383    | 2383    | 519     |
+| validSignerCount                               | 5595            | 22792  | 24595  | 56469   | 1813    |
+| validSignerHats                                | 548             | 548    | 548    | 548     | 2560    |
+
+
+| test/mocks/TestGuard.sol:TestGuard contract |                 |       |        |       |         |
+|---------------------------------------------|-----------------|-------|--------|-------|---------|
+| Deployment Cost                             | Deployment Size |       |        |       |         |
+| 588049                                      | 2727            |       |        |       |         |
+| Function Name                               | min             | avg   | median | max   | # calls |
+| disallowExecution                           | 43338           | 43338 | 43338  | 43338 | 1       |
+| supportsInterface                           | 350             | 350   | 350    | 350   | 516     |
 
 
 
 
-Ran 15 test suites in 957.57ms (6.95s CPU time): 68 tests passed, 0 failed, 0 skipped (68 total tests)
+Ran 25 test suites in 118.17s (618.38s CPU time): 115 tests passed, 0 failed, 0 skipped (115 total tests)

--- a/script/DeployParams.json
+++ b/script/DeployParams.json
@@ -2,7 +2,7 @@
   "100": {
     "hatsProtocol": "0x3bc1A0Ad72417f2d411118085256fC53CBdDd137",
     "safeFallbackLibrary": "0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99",
-    "safeMultisendLibrary": "0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526",
+    "safeMultisendLibrary": "0x9641d764fc13c8B624c04430C7356C1C7C8102e2",
     "safeProxyFactory": "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",
     "safeSingleton": "0x29fcB43b46531BcA003ddC8FCB67FFE91900C762",
     "zodiacModuleFactory": "0x000000000000aDdB49795b0f9bA5BC298cDda236"
@@ -10,7 +10,7 @@
   "1": {
     "hatsProtocol": "0x3bc1A0Ad72417f2d411118085256fC53CBdDd137",
     "safeFallbackLibrary": "0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99",
-    "safeMultisendLibrary": "0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526",
+    "safeMultisendLibrary": "0x9641d764fc13c8B624c04430C7356C1C7C8102e2",
     "safeProxyFactory": "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",
     "safeSingleton": "0x29fcB43b46531BcA003ddC8FCB67FFE91900C762",
     "zodiacModuleFactory": "0x000000000000aDdB49795b0f9bA5BC298cDda236"
@@ -18,7 +18,7 @@
   "10": {
     "hatsProtocol": "0x3bc1A0Ad72417f2d411118085256fC53CBdDd137",
     "safeFallbackLibrary": "0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99",
-    "safeMultisendLibrary": "0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526",
+    "safeMultisendLibrary": "0x9641d764fc13c8B624c04430C7356C1C7C8102e2",
     "safeProxyFactory": "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",
     "safeSingleton": "0x29fcB43b46531BcA003ddC8FCB67FFE91900C762",
     "zodiacModuleFactory": "0x000000000000aDdB49795b0f9bA5BC298cDda236"
@@ -26,7 +26,7 @@
   "137": {
     "hatsProtocol": "0x3bc1A0Ad72417f2d411118085256fC53CBdDd137",
     "safeFallbackLibrary": "0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99",
-    "safeMultisendLibrary": "0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526",
+    "safeMultisendLibrary": "0x9641d764fc13c8B624c04430C7356C1C7C8102e2",
     "safeProxyFactory": "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",
     "safeSingleton": "0x29fcB43b46531BcA003ddC8FCB67FFE91900C762",
     "zodiacModuleFactory": "0x000000000000aDdB49795b0f9bA5BC298cDda236"
@@ -34,7 +34,7 @@
   "42161": {
     "hatsProtocol": "0x3bc1A0Ad72417f2d411118085256fC53CBdDd137",
     "safeFallbackLibrary": "0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99",
-    "safeMultisendLibrary": "0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526",
+    "safeMultisendLibrary": "0x9641d764fc13c8B624c04430C7356C1C7C8102e2",
     "safeProxyFactory": "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",
     "safeSingleton": "0x29fcB43b46531BcA003ddC8FCB67FFE91900C762",
     "zodiacModuleFactory": "0x000000000000aDdB49795b0f9bA5BC298cDda236"
@@ -42,7 +42,7 @@
   "11155111": {
     "hatsProtocol": "0x3bc1A0Ad72417f2d411118085256fC53CBdDd137",
     "safeFallbackLibrary": "0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99",
-    "safeMultisendLibrary": "0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526",
+    "safeMultisendLibrary": "0x9641d764fc13c8B624c04430C7356C1C7C8102e2",
     "safeProxyFactory": "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",
     "safeSingleton": "0x29fcB43b46531BcA003ddC8FCB67FFE91900C762",
     "zodiacModuleFactory": "0x000000000000aDdB49795b0f9bA5BC298cDda236"
@@ -50,7 +50,7 @@
   "8453": {
     "hatsProtocol": "0x3bc1A0Ad72417f2d411118085256fC53CBdDd137",
     "safeFallbackLibrary": "0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99",
-    "safeMultisendLibrary": "0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526",
+    "safeMultisendLibrary": "0x9641d764fc13c8B624c04430C7356C1C7C8102e2",
     "safeProxyFactory": "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",
     "safeSingleton": "0x29fcB43b46531BcA003ddC8FCB67FFE91900C762",
     "zodiacModuleFactory": "0x000000000000aDdB49795b0f9bA5BC298cDda236"
@@ -58,7 +58,7 @@
   "42220": {
     "hatsProtocol": "0x3bc1A0Ad72417f2d411118085256fC53CBdDd137",
     "safeFallbackLibrary": "0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99",
-    "safeMultisendLibrary": "0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526",
+    "safeMultisendLibrary": "0x9641d764fc13c8B624c04430C7356C1C7C8102e2",
     "safeProxyFactory": "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",
     "safeSingleton": "0x29fcB43b46531BcA003ddC8FCB67FFE91900C762",
     "zodiacModuleFactory": "0x000000000000aDdB49795b0f9bA5BC298cDda236"

--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -61,6 +61,9 @@ contract HatsSignerGate is
   mapping(address => uint256) public claimedSignerHats;
 
   /// @inheritdoc IHatsSignerGate
+  mapping(address => bool) public enabledDelegatecallTargets;
+
+  /// @inheritdoc IHatsSignerGate
   uint256 public ownerHat;
 
   /// @inheritdoc IHatsSignerGate
@@ -335,6 +338,24 @@ contract HatsSignerGate is
       IHatsSignerGate(_newHSG).claimSignersFor(_signerHatIds, _signersToMigrate);
     }
     emit Migrated(_newHSG);
+  }
+
+  /// @inheritdoc IHatsSignerGate
+  function enableDelegatecallTarget(address _target) public {
+    _checkUnlocked();
+    _checkOwner();
+
+    enabledDelegatecallTargets[_target] = true;
+    emit DelegatecallTargetEnabled(_target, true);
+  }
+
+  /// @inheritdoc IHatsSignerGate
+  function disableDelegatecallTarget(address _target) public {
+    _checkUnlocked();
+    _checkOwner();
+
+    enabledDelegatecallTargets[_target] = false;
+    emit DelegatecallTargetEnabled(_target, false);
   }
 
   /*//////////////////////////////////////////////////////////////

--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -168,12 +168,9 @@ contract HatsSignerGate is
     if (params.hsgGuard != address(0)) _setGuard(params.hsgGuard);
 
     // enable default delegatecall targets
-    _setDelegatecallTarget(0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761, true); // multisend v1.3.0 "canonical"
-    _setDelegatecallTarget(0x998739BFdAAdde7C933B942a68053933098f9EDa, true); // multisend v1.3.0 "eip155"
     _setDelegatecallTarget(0x40A2aCCbd92BCA938b02010E17A5b8929b49130D, true); // multisend-call-only v1.3.0 "canonical"
     _setDelegatecallTarget(0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B, true); // multisend-call-only v1.3.0 "eip155"
-    _setDelegatecallTarget(0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526, true); // multisend v1.4.1 "canonical"
-    _setDelegatecallTarget(0x9641d764fc13c8B624c04430C7356C1C7C8102e2, true); // multisend-call-only v1.4.1 "eip155"
+    _setDelegatecallTarget(0x9641d764fc13c8B624c04430C7356C1C7C8102e2, true); // multisend-call-only v1.4.1 "canonical"
   }
 
   /*//////////////////////////////////////////////////////////////

--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -821,7 +821,7 @@ contract HatsSignerGate is
   //                     ZODIAC MODIFIER FUNCTIONS
   // //////////////////////////////////////////////////////////////*/
 
-  /// @dev Allows a Module to execute a transaction.
+  /// @dev Allows a Module to execute a call. Delegatecalls are not allowed.
   /// @notice Can only be called by an enabled module.
   /// @notice Must emit ExecutionFromModuleSuccess(address module) if successful.
   /// @notice Must emit ExecutionFromModuleFailure(address module) if unsuccessful.
@@ -835,8 +835,8 @@ contract HatsSignerGate is
     moduleOnly
     returns (bool success)
   {
-    // disallow delegatecalls to unapproved targets
-    if (operation == Enum.Operation.DelegateCall) _checkDelegatecallTarget(to);
+    // disallow delegatecalls
+    if (operation == Enum.Operation.DelegateCall) revert ModulesCannotDelegatecall();
 
     // disallow external calls to the safe
     if (to == address(safe)) revert ModulesCannotCallSafe();
@@ -852,7 +852,7 @@ contract HatsSignerGate is
     }
   }
 
-  /// @dev Allows a Module to execute a transaction and return data
+  /// @dev Allows a Module to execute a call with return data. Delegatecalls are not allowed.
   /// @notice Can only be called by an enabled module.
   /// @notice Must emit ExecutionFromModuleSuccess(address module) if successful.
   /// @notice Must emit ExecutionFromModuleFailure(address module) if unsuccessful.
@@ -866,8 +866,8 @@ contract HatsSignerGate is
     moduleOnly
     returns (bool success, bytes memory returnData)
   {
-    // disallow delegatecalls to unapproved targets
-    if (operation == Enum.Operation.DelegateCall) _checkDelegatecallTarget(to);
+    // disallow delegatecalls
+    if (operation == Enum.Operation.DelegateCall) revert ModulesCannotDelegatecall();
 
     // disallow external calls to the safe
     if (to == address(safe)) revert ModulesCannotCallSafe();

--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -84,11 +84,15 @@ contract HatsSignerGate is
   /// @inheritdoc IHatsSignerGate
   address public implementation;
 
+  /*//////////////////////////////////////////////////////////////
+                          TRANSIENT STATE
+  //////////////////////////////////////////////////////////////*/
+
   /// @dev Temporary record of the existing owners on the `safe` when a transaction is submitted
-  bytes32 internal _existingOwnersHash;
+  bytes32 transient _existingOwnersHash;
 
   /// @dev A simple re-entrency guard
-  uint256 internal _guardEntries;
+  uint256 transient _guardEntries;
 
   /*//////////////////////////////////////////////////////////////
                       AUTHENTICATION FUNCTIONS
@@ -435,10 +439,8 @@ contract HatsSignerGate is
     if (validSigCount < threshold || validSigCount < minThreshold) revert InsufficientValidSignatures();
 
     // record existing owners for post-flight check
-    // TODO use TSTORE
     _existingOwnersHash = keccak256(abi.encode(owners));
 
-    // TODO use TSTORE
     unchecked {
       ++_guardEntries;
     }

--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -84,11 +84,15 @@ contract HatsSignerGate is
   /// @inheritdoc IHatsSignerGate
   address public implementation;
 
+  /*//////////////////////////////////////////////////////////////
+                          TRANSIENT STATE
+  //////////////////////////////////////////////////////////////*/
+
   /// @dev Temporary record of the existing owners on the `safe` when a transaction is submitted
-  bytes32 internal _existingOwnersHash;
+  bytes32 transient _existingOwnersHash;
 
   /// @dev A simple re-entrency guard
-  uint256 internal _guardEntries;
+  uint256 transient _guardEntries;
 
   /*//////////////////////////////////////////////////////////////
                       AUTHENTICATION FUNCTIONS
@@ -438,10 +442,8 @@ contract HatsSignerGate is
     if (validSigCount < threshold || validSigCount < minThreshold) revert InsufficientValidSignatures();
 
     // record existing owners for post-flight check
-    // TODO use TSTORE
     _existingOwnersHash = keccak256(abi.encode(owners));
 
-    // TODO use TSTORE
     unchecked {
       ++_guardEntries;
     }

--- a/src/interfaces/IHatsSignerGate.sol
+++ b/src/interfaces/IHatsSignerGate.sol
@@ -98,6 +98,9 @@ interface IHatsSignerGate {
   /// @dev This ensures that modules cannot change any of the `safe`'s settings
   error ModulesCannotCallSafe();
 
+  /// @notice The delegatecall target is not enabled
+  error DelegatecallTargetNotEnabled();
+
   /*//////////////////////////////////////////////////////////////
                               EVENTS
   //////////////////////////////////////////////////////////////*/

--- a/src/interfaces/IHatsSignerGate.sol
+++ b/src/interfaces/IHatsSignerGate.sol
@@ -98,6 +98,9 @@ interface IHatsSignerGate {
   /// @dev This ensures that modules cannot change any of the `safe`'s settings
   error ModulesCannotCallSafe();
 
+  /// @notice Modules enabled on HSG cannot delegatecall
+  error ModulesCannotDelegatecall();
+
   /// @notice The delegatecall target is not enabled
   error DelegatecallTargetNotEnabled();
 
@@ -259,12 +262,12 @@ interface IHatsSignerGate {
   function migrateToNewHSG(address _newHSG, uint256[] calldata _signerHatIds, address[] calldata _signersToMigrate)
     external;
 
-  /// @notice Enables a delegatecall target. Enabled targets can be delegatecalled by the `safe` or its modules.
+  /// @notice Enables a target contract to be delegatecall-able by the `safe`.
   /// @dev Only callable by a wearer of the owner hat, and only if the contract is not locked.
   /// @param _target The target addressto enable
   function enableDelegatecallTarget(address _target) external;
 
-  /// @notice Disables a delegatecall target. Disabled targets cannot be delegatecalled by the `safe` or its modules.
+  /// @notice Disables a target contract from being delegatecall-able by the `safe`.
   /// @dev Only callable by a wearer of the owner hat, and only if the contract is not locked.
   /// @param _target The target address to disable
   function disableDelegatecallTarget(address _target) external;

--- a/src/interfaces/IHatsSignerGate.sol
+++ b/src/interfaces/IHatsSignerGate.sol
@@ -126,6 +126,9 @@ interface IHatsSignerGate {
   /// @notice Emitted when HSG has been migrated to a new HSG
   event Migrated(address newHSG);
 
+  /// @notice Emitted when a delegatecall target is enabled
+  event DelegatecallTargetEnabled(address target, bool enabled);
+
   /*//////////////////////////////////////////////////////////////
                           CONSTANTS
   //////////////////////////////////////////////////////////////*/
@@ -145,6 +148,9 @@ interface IHatsSignerGate {
 
   /// @notice Tracks the hat ids worn by users who have "claimed signer"
   function claimedSignerHats(address) external view returns (uint256);
+
+  /// @notice Tracks enabled delegatecall targets. Enabled targets can be delegatecalled by the `safe`
+  function enabledDelegatecallTargets(address) external view returns (bool);
 
   /// @notice The owner hat
   function ownerHat() external view returns (uint256);
@@ -249,6 +255,16 @@ interface IHatsSignerGate {
   /// signers to migrate. `_newHSG` must have claimableFor==TRUE to migrate signers.
   function migrateToNewHSG(address _newHSG, uint256[] calldata _signerHatIds, address[] calldata _signersToMigrate)
     external;
+
+  /// @notice Enables a delegatecall target. Enabled targets can be delegatecalled by the `safe` or its modules.
+  /// @dev Only callable by a wearer of the owner hat, and only if the contract is not locked.
+  /// @param _target The target addressto enable
+  function enableDelegatecallTarget(address _target) external;
+
+  /// @notice Disables a delegatecall target. Disabled targets cannot be delegatecalled by the `safe` or its modules.
+  /// @dev Only callable by a wearer of the owner hat, and only if the contract is not locked.
+  /// @param _target The target address to disable
+  function disableDelegatecallTarget(address _target) external;
 
   /*//////////////////////////////////////////////////////////////
                           VIEW FUNCTIONS

--- a/test/HatsSignerGate.attacks.t.sol
+++ b/test/HatsSignerGate.attacks.t.sol
@@ -11,7 +11,7 @@ contract AttacksScenarios is WithHSGInstanceTest {
 
     _addSignersSameHat(2, signerHat);
 
-    bytes32 txHash = _getTxHash(address(safe), 0, addModuleData, safe);
+    bytes32 txHash = _getTxHash(address(safe), 0, Enum.Operation.Call, addModuleData, safe);
 
     bytes memory signatures = _createNSigsForTx(txHash, 2);
 
@@ -61,7 +61,7 @@ contract AttacksScenarios is WithHSGInstanceTest {
 
     // have just 2 of 5 signers sign it
     // create the tx
-    bytes32 txHash = _getTxHash(destAddress, transferValue, hex"00", safe);
+    bytes32 txHash = _getTxHash(destAddress, transferValue, Enum.Operation.Call, hex"00", safe);
     // have them sign it
     bytes memory signatures = _createNSigsForTx(txHash, 2);
 

--- a/test/HatsSignerGate.attacks.t.sol
+++ b/test/HatsSignerGate.attacks.t.sol
@@ -284,7 +284,7 @@ contract AttacksScenarios is WithHSGInstanceTest {
 
     // now get the safe tx hash and have attacker sign it with a collaborator
     bytes32 safeTxHash = safe.getTransactionHash(
-      safeMultisendLibrary, // to
+      defaultDelegatecallTargets[0], // to an approved delegatecall target
       0, // value
       multisend, // data
       Enum.Operation.DelegateCall, // operation
@@ -308,7 +308,7 @@ contract AttacksScenarios is WithHSGInstanceTest {
         */
     vm.expectRevert(bytes("GS013"));
     safe.execTransaction(
-      safeMultisendLibrary,
+      defaultDelegatecallTargets[0], // to an approved delegatecall target
       0,
       multisend,
       Enum.Operation.DelegateCall,

--- a/test/HatsSignerGate.t.sol
+++ b/test/HatsSignerGate.t.sol
@@ -1871,43 +1871,14 @@ contract ExecutingFromModuleViaHSG is WithHSGInstanceTest {
     hatsSignerGate.execTransactionFromModule(address(safe), transferValue, hex"00", Enum.Operation.Call);
   }
 
-  function test_revert_delegatecallTargetNotEnabled() public {
+  function test_revert_delegateCallsNotAllowed() public {
     address target = makeAddr("target");
 
     bytes memory data = abi.encodeWithSignature("maliciousCall()");
 
-    vm.expectRevert(IHatsSignerGate.DelegatecallTargetNotEnabled.selector);
+    vm.expectRevert(IHatsSignerGate.ModulesCannotDelegatecall.selector);
     vm.prank(newModule);
     hatsSignerGate.execTransactionFromModule(target, 0, data, Enum.Operation.DelegateCall);
-  }
-
-  function test_happy_delegateCall() public {
-    // encode a call that we know will be successful
-    bytes memory data = abi.encodeWithSelector(IHats.isWearerOfHat.selector, signerAddresses[0], signerHat);
-
-    // wrap it in a multisend call
-    bytes memory multisendData = abi.encodePacked(
-      Enum.Operation.Call, // 0 for call; 1 for delegatecall
-      address(hats), // to
-      uint256(0), // value
-      uint256(data.length), // data length
-      data // data
-    );
-
-    // encode the multisend call
-    bytes memory multisendCall = abi.encodeWithSelector(MultiSend.multiSend.selector, multisendData);
-
-    // have the new module send the multisend call to each of the default delegatecall targets
-    for (uint256 i; i < defaultDelegatecallTargets.length; ++i) {
-      vm.expectEmit();
-      emit IModuleManager.ExecutionFromModuleSuccess(address(hatsSignerGate));
-      vm.expectEmit();
-      emit IAvatar.ExecutionFromModuleSuccess(newModule);
-      vm.prank(newModule);
-      hatsSignerGate.execTransactionFromModule(
-        defaultDelegatecallTargets[i], 0, multisendCall, Enum.Operation.DelegateCall
-      );
-    }
   }
 }
 
@@ -1979,43 +1950,14 @@ contract ExecutingFromModuleReturnDataViaHSG is WithHSGInstanceTest {
     hatsSignerGate.execTransactionFromModuleReturnData(address(safe), transferValue, hex"00", Enum.Operation.Call);
   }
 
-  function test_revert_delegatecallTargetNotEnabled() public {
+  function test_revert_delegateCallsNotAllowed() public {
     address target = makeAddr("target");
 
     bytes memory data = abi.encodeWithSignature("maliciousCall()");
 
-    vm.expectRevert(IHatsSignerGate.DelegatecallTargetNotEnabled.selector);
+    vm.expectRevert(IHatsSignerGate.ModulesCannotDelegatecall.selector);
     vm.prank(newModule);
     hatsSignerGate.execTransactionFromModuleReturnData(target, 0, data, Enum.Operation.DelegateCall);
-  }
-
-  function test_success_defaultDelegatecallTargets() public {
-    // encode a call that we know will be successful
-    bytes memory data = abi.encodeWithSelector(IHats.isWearerOfHat.selector, signerAddresses[0], signerHat);
-
-    // wrap it in a multisend call
-    bytes memory multisendData = abi.encodePacked(
-      Enum.Operation.Call, // 0 for call; 1 for delegatecall
-      address(hats), // to
-      uint256(0), // value
-      uint256(data.length), // data length
-      data // data
-    );
-
-    // encode the multisend call
-    bytes memory multisendCall = abi.encodeWithSelector(MultiSend.multiSend.selector, multisendData);
-
-    // have the new module send the multisend call to each of the default delegatecall targets
-    for (uint256 i; i < defaultDelegatecallTargets.length; ++i) {
-      vm.expectEmit();
-      emit IModuleManager.ExecutionFromModuleSuccess(address(hatsSignerGate));
-      vm.expectEmit();
-      emit IAvatar.ExecutionFromModuleSuccess(newModule);
-      vm.prank(newModule);
-      hatsSignerGate.execTransactionFromModuleReturnData(
-        defaultDelegatecallTargets[i], 0, multisendCall, Enum.Operation.DelegateCall
-      );
-    }
   }
 }
 

--- a/test/HatsSignerGate.t.sol
+++ b/test/HatsSignerGate.t.sol
@@ -3,13 +3,14 @@ pragma solidity ^0.8.13;
 
 import { Test, console2 } from "../lib/forge-std/src/Test.sol";
 import { Enum, ISafe, TestSuite, WithHSGInstanceTest, HatsSignerGate } from "./TestSuite.t.sol";
-import { IHatsSignerGate } from "../src/interfaces/IHatsSignerGate.sol";
+import { IHats, IHatsSignerGate } from "../src/interfaces/IHatsSignerGate.sol";
 import { DeployInstance } from "../script/HatsSignerGate.s.sol";
 import { IAvatar } from "../src/lib/zodiac-modified/ModifierUnowned.sol";
 import { IModuleManager } from "../src/lib/safe-interfaces/IModuleManager.sol";
 import { GuardableUnowned } from "../src/lib/zodiac-modified/GuardableUnowned.sol";
 import { ModifierUnowned } from "../src/lib/zodiac-modified/ModifierUnowned.sol";
 import { TestGuard } from "./mocks/TestGuard.sol";
+import { MultiSend } from "../lib/safe-smart-account/contracts/libraries/MultiSend.sol";
 
 contract Deployment is TestSuite {
   // errors from dependencies
@@ -56,6 +57,13 @@ contract Deployment is TestSuite {
     assertEq(hatsSignerGate.claimableFor(), _claimableFor);
     assertEq(address(hatsSignerGate.getGuard()), address(tstGuard));
     assertCorrectModules(tstModules);
+
+    // check that the default delegatecall targets are enabled
+    for (uint256 i; i < defaultDelegatecallTargets.length; ++i) {
+      assertTrue(
+        hatsSignerGate.enabledDelegatecallTargets(defaultDelegatecallTargets[i]), "default target should be enabled"
+      );
+    }
   }
 
   function test_andSafe(bool _locked, bool _claimableFor) public {
@@ -85,6 +93,13 @@ contract Deployment is TestSuite {
     assertEq(hatsSignerGate.claimableFor(), _claimableFor);
     assertEq(address(hatsSignerGate.getGuard()), address(tstGuard));
     assertCorrectModules(tstModules);
+
+    // check that the default delegatecall targets are enabled
+    for (uint256 i; i < defaultDelegatecallTargets.length; ++i) {
+      assertTrue(
+        hatsSignerGate.enabledDelegatecallTargets(defaultDelegatecallTargets[i]), "default target should be enabled"
+      );
+    }
   }
 
   function test_revert_reinitializeImplementation() public {
@@ -414,6 +429,8 @@ contract RemovingSigners is WithHSGInstanceTest {
 }
 
 contract ExecutingTransactions is WithHSGInstanceTest {
+  event ExecutionSuccess(bytes32 indexed txHash, uint256 payment);
+
   function testExecTxByHatWearers() public {
     _addSignersSameHat(3, signerHat);
 
@@ -426,7 +443,7 @@ contract ExecutingTransactions is WithHSGInstanceTest {
     hoax(address(safe), preValue);
 
     // create the tx
-    bytes32 txHash = _getTxHash(destAddress, transferValue, hex"00", safe);
+    bytes32 txHash = _getTxHash(destAddress, transferValue, Enum.Operation.Call, hex"00", safe);
 
     // have 3 signers sign it
     bytes memory signatures = _createNSigsForTx(txHash, 3);
@@ -466,7 +483,7 @@ contract ExecutingTransactions is WithHSGInstanceTest {
     // emit log_uint(address(safe).balance);
     // create tx to send some eth from safe to wherever
     // create the tx
-    bytes32 txHash = _getTxHash(destAddress, transferValue, hex"00", safe);
+    bytes32 txHash = _getTxHash(destAddress, transferValue, Enum.Operation.Call, hex"00", safe);
 
     // have 3 signers sign it
     bytes memory signatures = _createNSigsForTx(txHash, 3);
@@ -516,7 +533,7 @@ contract ExecutingTransactions is WithHSGInstanceTest {
 
     // have the remaining signer sign it
     // create the tx
-    bytes32 txHash = _getTxHash(destAddress, transferValue, hex"00", safe);
+    bytes32 txHash = _getTxHash(destAddress, transferValue, Enum.Operation.Call, hex"00", safe);
 
     // have them sign it
     bytes memory signatures = _createNSigsForTx(txHash, 1);
@@ -563,7 +580,7 @@ contract ExecutingTransactions is WithHSGInstanceTest {
 
     // have the remaining signer sign it
     // create the tx
-    bytes32 txHash = _getTxHash(destAddress, transferValue, hex"00", safe);
+    bytes32 txHash = _getTxHash(destAddress, transferValue, Enum.Operation.Call, hex"00", safe);
     // have both signers (1 valid, 1 invalid) sign it
     bytes memory signatures = _createNSigsForTx(txHash, 2);
 
@@ -596,7 +613,7 @@ contract ExecutingTransactions is WithHSGInstanceTest {
     hoax(address(safe), preValue);
 
     // create the tx
-    bytes32 txHash = _getTxHash(destAddress, transferValue, hex"00", safe);
+    bytes32 txHash = _getTxHash(destAddress, transferValue, Enum.Operation.Call, hex"00", safe);
 
     // have 3 signers sign it
     bytes memory signatures = _createNSigsForTx(txHash, 3);
@@ -635,7 +652,7 @@ contract ExecutingTransactions is WithHSGInstanceTest {
     // emit log_uint(address(safe).balance);
     // create tx to send some eth from safe to wherever
     // create the tx
-    bytes32 txHash = _getTxHash(destAddress, transferValue, hex"00", safe);
+    bytes32 txHash = _getTxHash(destAddress, transferValue, Enum.Operation.Call, hex"00", safe);
 
     // have 3 signers sign it
     bytes memory signatures = _createNSigsForTx(txHash, 3);
@@ -669,6 +686,85 @@ contract ExecutingTransactions is WithHSGInstanceTest {
     assertEq(destAddress.balance, 0);
     assertEq(safe.nonce(), preNonce);
   }
+
+  function test_happy_delegateCall() public {
+    _addSignersSameHat(2, signerHat);
+
+    // encode a call that we know will be successful
+    bytes memory data = abi.encodeWithSelector(IHats.isWearerOfHat.selector, signerAddresses[0], signerHat);
+
+    // wrap it in a multisend call
+    bytes memory multisendData = abi.encodePacked(
+      Enum.Operation.Call, // 0 for call; 1 for delegatecall
+      address(hats), // to
+      uint256(0), // value
+      uint256(data.length), // data length
+      data // data
+    );
+
+    // encode the multisend call
+    bytes memory multisendCall = abi.encodeWithSelector(MultiSend.multiSend.selector, multisendData);
+
+    // execute the multisend to each of the default delegatecall targets
+    for (uint256 i = 0; i < defaultDelegatecallTargets.length; i++) {
+      // get the tx hash
+      bytes32 txHash = _getTxHash(defaultDelegatecallTargets[i], 0, Enum.Operation.DelegateCall, multisendCall, safe);
+
+      // have the signers sign it
+      bytes memory signatures = _createNSigsForTx(txHash, 2);
+
+      // have one of the signers exec the multisend call
+      vm.expectEmit();
+      emit ExecutionSuccess(txHash, 0);
+      vm.prank(signerAddresses[0]);
+      safe.execTransaction(
+        defaultDelegatecallTargets[i],
+        0,
+        multisendCall,
+        Enum.Operation.DelegateCall,
+        0,
+        0,
+        0,
+        address(0),
+        payable(address(0)),
+        signatures
+      );
+    }
+  }
+
+  function test_revert_delegateCallTargetNotEnabled() public {
+    address target = makeAddr("target");
+
+    _addSignersSameHat(2, signerHat);
+
+    // encode a call that we know will be successful
+    bytes memory data = abi.encodeWithSelector(IHats.isWearerOfHat.selector, signerAddresses[0], signerHat);
+
+    // wrap it in a multisend call
+    bytes memory multisendData = abi.encodePacked(
+      Enum.Operation.Call, // 0 for call; 1 for delegatecall
+      address(hats), // to
+      uint256(0), // value
+      uint256(data.length), // data length
+      data // data
+    );
+
+    // encode the multisend call
+    bytes memory multisendCall = abi.encodeWithSelector(MultiSend.multiSend.selector, multisendData);
+
+    // get the tx hash
+    bytes32 txHash = _getTxHash(target, 0, Enum.Operation.DelegateCall, multisendCall, safe);
+
+    // have the signers sign it
+    bytes memory signatures = _createNSigsForTx(txHash, 2);
+
+    // have one of the signers exec the multisend call
+    vm.expectRevert(IHatsSignerGate.DelegatecallTargetNotEnabled.selector);
+    vm.prank(signerAddresses[0]);
+    safe.execTransaction(
+      target, 0, multisendCall, Enum.Operation.DelegateCall, 0, 0, 0, address(0), payable(address(0)), signatures
+    );
+  }
 }
 
 contract ConstrainingSigners is WithHSGInstanceTest {
@@ -678,7 +774,7 @@ contract ConstrainingSigners is WithHSGInstanceTest {
 
     _addSignersSameHat(2, signerHat);
 
-    bytes32 txHash = _getTxHash(address(safe), 0, disableModuleData, safe);
+    bytes32 txHash = _getTxHash(address(safe), 0, Enum.Operation.Call, disableModuleData, safe);
 
     bytes memory signatures = _createNSigsForTx(txHash, 2);
 
@@ -707,7 +803,7 @@ contract ConstrainingSigners is WithHSGInstanceTest {
 
     _addSignersSameHat(2, signerHat);
 
-    bytes32 txHash = _getTxHash(address(safe), 0, disableGuardData, safe);
+    bytes32 txHash = _getTxHash(address(safe), 0, Enum.Operation.Call, disableGuardData, safe);
 
     bytes memory signatures = _createNSigsForTx(txHash, 2);
 
@@ -736,7 +832,7 @@ contract ConstrainingSigners is WithHSGInstanceTest {
     // data to increase the threshold data by 1
     bytes memory changeThresholdData = abi.encodeWithSignature("changeThreshold(uint256)", oldThreshold + 1);
 
-    bytes32 txHash = _getTxHash(address(safe), 0, changeThresholdData, safe);
+    bytes32 txHash = _getTxHash(address(safe), 0, Enum.Operation.Call, changeThresholdData, safe);
 
     bytes memory signatures = _createNSigsForTx(txHash, 2);
 
@@ -765,7 +861,7 @@ contract ConstrainingSigners is WithHSGInstanceTest {
     // data to decrease the threshold data by 1
     bytes memory changeThresholdData = abi.encodeWithSignature("changeThreshold(uint256)", oldThreshold - 1);
 
-    bytes32 txHash = _getTxHash(address(safe), 0, changeThresholdData, safe);
+    bytes32 txHash = _getTxHash(address(safe), 0, Enum.Operation.Call, changeThresholdData, safe);
 
     bytes memory signatures = _createNSigsForTx(txHash, 2);
 
@@ -794,7 +890,7 @@ contract ConstrainingSigners is WithHSGInstanceTest {
       safe.getThreshold() // threshold
     );
 
-    bytes32 txHash = _getTxHash(address(safe), 0, addOwnerData, safe);
+    bytes32 txHash = _getTxHash(address(safe), 0, Enum.Operation.Call, addOwnerData, safe);
     bytes memory signatures = _createNSigsForTx(txHash, 2);
 
     vm.expectRevert(abi.encodeWithSelector(IHatsSignerGate.SignersCannotChangeOwners.selector));
@@ -824,7 +920,7 @@ contract ConstrainingSigners is WithHSGInstanceTest {
       safe.getThreshold() // threshold
     );
 
-    bytes32 txHash = _getTxHash(address(safe), 0, removeOwnerData, safe);
+    bytes32 txHash = _getTxHash(address(safe), 0, Enum.Operation.Call, removeOwnerData, safe);
     bytes memory signatures = _createNSigsForTx(txHash, 2);
 
     vm.expectRevert(abi.encodeWithSelector(IHatsSignerGate.SignersCannotChangeOwners.selector));
@@ -855,7 +951,7 @@ contract ConstrainingSigners is WithHSGInstanceTest {
       toAdd // newOwner
     );
 
-    bytes32 txHash = _getTxHash(address(safe), 0, swapOwnerData, safe);
+    bytes32 txHash = _getTxHash(address(safe), 0, Enum.Operation.Call, swapOwnerData, safe);
     bytes memory signatures = _createNSigsForTx(txHash, 2);
 
     vm.expectRevert(abi.encodeWithSelector(IHatsSignerGate.SignersCannotChangeOwners.selector));
@@ -871,6 +967,22 @@ contract ConstrainingSigners is WithHSGInstanceTest {
       address(0),
       payable(address(0)),
       signatures
+    );
+  }
+
+  function test_revert_delegatecallTargetNotEnabled() public {
+    address target = makeAddr("target");
+
+    _addSignersSameHat(2, signerHat);
+
+    // craft a delegatecall to a non-enabled target
+    bytes memory data = abi.encodeWithSignature("maliciousCall()");
+    bytes32 txHash = _getTxHash(target, 0, Enum.Operation.DelegateCall, data, safe);
+    bytes memory signatures = _createNSigsForTx(txHash, 2);
+
+    vm.expectRevert(IHatsSignerGate.DelegatecallTargetNotEnabled.selector);
+    safe.execTransaction(
+      target, 0, data, Enum.Operation.DelegateCall, 0, 0, 0, address(0), payable(address(0)), signatures
     );
   }
 }
@@ -1505,7 +1617,7 @@ contract HSGGuarding is WithHSGInstanceTest {
     uint256 postValue = preValue - transferValue;
 
     // create the tx
-    bytes32 txHash = _getTxHash(recipient, transferValue, hex"00", safe);
+    bytes32 txHash = _getTxHash(recipient, transferValue, Enum.Operation.Call, hex"00", safe);
 
     // have 3 signers sign it
     bytes memory signatures = _createNSigsForTx(txHash, signerCount);
@@ -1546,7 +1658,7 @@ contract HSGGuarding is WithHSGInstanceTest {
     uint256 transferValue = disallowedValue;
 
     // create the tx
-    bytes32 txHash = _getTxHash(recipient, transferValue, hex"00", safe);
+    bytes32 txHash = _getTxHash(recipient, transferValue, Enum.Operation.Call, hex"00", safe);
 
     // have 3 signers sign it
     bytes memory signatures = _createNSigsForTx(txHash, signerCount);
@@ -1587,7 +1699,7 @@ contract HSGGuarding is WithHSGInstanceTest {
     uint256 transferValue = goodValue;
 
     // create the tx
-    bytes32 txHash = _getTxHash(recipient, transferValue, hex"00", safe);
+    bytes32 txHash = _getTxHash(recipient, transferValue, Enum.Operation.Call, hex"00", safe);
 
     // have 3 signers sign it
     bytes memory signatures = _createNSigsForTx(txHash, signerCount);
@@ -1758,6 +1870,45 @@ contract ExecutingFromModuleViaHSG is WithHSGInstanceTest {
     vm.prank(newModule);
     hatsSignerGate.execTransactionFromModule(address(safe), transferValue, hex"00", Enum.Operation.Call);
   }
+
+  function test_revert_delegatecallTargetNotEnabled() public {
+    address target = makeAddr("target");
+
+    bytes memory data = abi.encodeWithSignature("maliciousCall()");
+
+    vm.expectRevert(IHatsSignerGate.DelegatecallTargetNotEnabled.selector);
+    vm.prank(newModule);
+    hatsSignerGate.execTransactionFromModule(target, 0, data, Enum.Operation.DelegateCall);
+  }
+
+  function test_happy_delegateCall() public {
+    // encode a call that we know will be successful
+    bytes memory data = abi.encodeWithSelector(IHats.isWearerOfHat.selector, signerAddresses[0], signerHat);
+
+    // wrap it in a multisend call
+    bytes memory multisendData = abi.encodePacked(
+      Enum.Operation.Call, // 0 for call; 1 for delegatecall
+      address(hats), // to
+      uint256(0), // value
+      uint256(data.length), // data length
+      data // data
+    );
+
+    // encode the multisend call
+    bytes memory multisendCall = abi.encodeWithSelector(MultiSend.multiSend.selector, multisendData);
+
+    // have the new module send the multisend call to each of the default delegatecall targets
+    for (uint256 i; i < defaultDelegatecallTargets.length; ++i) {
+      vm.expectEmit();
+      emit IModuleManager.ExecutionFromModuleSuccess(address(hatsSignerGate));
+      vm.expectEmit();
+      emit IAvatar.ExecutionFromModuleSuccess(newModule);
+      vm.prank(newModule);
+      hatsSignerGate.execTransactionFromModule(
+        defaultDelegatecallTargets[i], 0, multisendCall, Enum.Operation.DelegateCall
+      );
+    }
+  }
 }
 
 contract ExecutingFromModuleReturnDataViaHSG is WithHSGInstanceTest {
@@ -1826,6 +1977,45 @@ contract ExecutingFromModuleReturnDataViaHSG is WithHSGInstanceTest {
     vm.expectRevert(IHatsSignerGate.ModulesCannotCallSafe.selector);
     vm.prank(newModule);
     hatsSignerGate.execTransactionFromModuleReturnData(address(safe), transferValue, hex"00", Enum.Operation.Call);
+  }
+
+  function test_revert_delegatecallTargetNotEnabled() public {
+    address target = makeAddr("target");
+
+    bytes memory data = abi.encodeWithSignature("maliciousCall()");
+
+    vm.expectRevert(IHatsSignerGate.DelegatecallTargetNotEnabled.selector);
+    vm.prank(newModule);
+    hatsSignerGate.execTransactionFromModuleReturnData(target, 0, data, Enum.Operation.DelegateCall);
+  }
+
+  function test_success_defaultDelegatecallTargets() public {
+    // encode a call that we know will be successful
+    bytes memory data = abi.encodeWithSelector(IHats.isWearerOfHat.selector, signerAddresses[0], signerHat);
+
+    // wrap it in a multisend call
+    bytes memory multisendData = abi.encodePacked(
+      Enum.Operation.Call, // 0 for call; 1 for delegatecall
+      address(hats), // to
+      uint256(0), // value
+      uint256(data.length), // data length
+      data // data
+    );
+
+    // encode the multisend call
+    bytes memory multisendCall = abi.encodeWithSelector(MultiSend.multiSend.selector, multisendData);
+
+    // have the new module send the multisend call to each of the default delegatecall targets
+    for (uint256 i; i < defaultDelegatecallTargets.length; ++i) {
+      vm.expectEmit();
+      emit IModuleManager.ExecutionFromModuleSuccess(address(hatsSignerGate));
+      vm.expectEmit();
+      emit IAvatar.ExecutionFromModuleSuccess(newModule);
+      vm.prank(newModule);
+      hatsSignerGate.execTransactionFromModuleReturnData(
+        defaultDelegatecallTargets[i], 0, multisendCall, Enum.Operation.DelegateCall
+      );
+    }
   }
 }
 

--- a/test/TestSuite.t.sol
+++ b/test/TestSuite.t.sol
@@ -38,7 +38,7 @@ abstract contract SafeTestHelpers is Test {
     );
   }
 
-  function _getTxHash(address _to, uint256 _value, bytes memory _data, ISafe _safe)
+  function _getTxHash(address _to, uint256 _value, Enum.Operation _operation, bytes memory _data, ISafe _safe)
     internal
     view
     returns (bytes32 txHash)
@@ -47,7 +47,7 @@ abstract contract SafeTestHelpers is Test {
       _to,
       _value,
       _data,
-      Enum.Operation.Call,
+      _operation,
       // not using the refunder
       0,
       0,
@@ -236,6 +236,15 @@ contract TestSuite is SafeTestHelpers {
   address public toggle = makeAddr("toggle");
   address public other = makeAddr("other");
 
+  // Test delegatecall targets
+  address[] public defaultDelegatecallTargets;
+  address public v1_3_0_canonical = 0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761;
+  address public v1_3_0_eip155 = 0x998739BFdAAdde7C933B942a68053933098f9EDa;
+  address public v1_3_0_callOnly_canonical = 0x40A2aCCbd92BCA938b02010E17A5b8929b49130D;
+  address public v1_3_0_callOnly_eip155 = 0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B;
+  address public v1_4_1_canonical = 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526;
+  address public v1_4_1_callOnly_canonical = 0x9641d764fc13c8B624c04430C7356C1C7C8102e2;
+
   // Test hats
   uint256 public tophat;
   uint256 public ownerHat;
@@ -296,6 +305,15 @@ contract TestSuite is SafeTestHelpers {
     tstModules[0] = tstModule1;
     tstModules[1] = tstModule2;
     tstModules[2] = tstModule3;
+
+    // set up the default delegatecall targets array
+    defaultDelegatecallTargets = new address[](6);
+    defaultDelegatecallTargets[0] = v1_3_0_canonical;
+    defaultDelegatecallTargets[1] = v1_3_0_eip155;
+    defaultDelegatecallTargets[2] = v1_3_0_callOnly_canonical;
+    defaultDelegatecallTargets[3] = v1_3_0_callOnly_eip155;
+    defaultDelegatecallTargets[4] = v1_4_1_canonical;
+    defaultDelegatecallTargets[5] = v1_4_1_callOnly_canonical;
 
     // Set up the test hats
     uint256 signerHatCount = 5;

--- a/test/TestSuite.t.sol
+++ b/test/TestSuite.t.sol
@@ -238,11 +238,8 @@ contract TestSuite is SafeTestHelpers {
 
   // Test delegatecall targets
   address[] public defaultDelegatecallTargets;
-  address public v1_3_0_canonical = 0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761;
-  address public v1_3_0_eip155 = 0x998739BFdAAdde7C933B942a68053933098f9EDa;
   address public v1_3_0_callOnly_canonical = 0x40A2aCCbd92BCA938b02010E17A5b8929b49130D;
   address public v1_3_0_callOnly_eip155 = 0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B;
-  address public v1_4_1_canonical = 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526;
   address public v1_4_1_callOnly_canonical = 0x9641d764fc13c8B624c04430C7356C1C7C8102e2;
 
   // Test hats
@@ -307,13 +304,10 @@ contract TestSuite is SafeTestHelpers {
     tstModules[2] = tstModule3;
 
     // set up the default delegatecall targets array
-    defaultDelegatecallTargets = new address[](6);
-    defaultDelegatecallTargets[0] = v1_3_0_canonical;
-    defaultDelegatecallTargets[1] = v1_3_0_eip155;
-    defaultDelegatecallTargets[2] = v1_3_0_callOnly_canonical;
-    defaultDelegatecallTargets[3] = v1_3_0_callOnly_eip155;
-    defaultDelegatecallTargets[4] = v1_4_1_canonical;
-    defaultDelegatecallTargets[5] = v1_4_1_callOnly_canonical;
+    defaultDelegatecallTargets = new address[](3);
+    defaultDelegatecallTargets[0] = v1_3_0_callOnly_canonical;
+    defaultDelegatecallTargets[1] = v1_3_0_callOnly_eip155;
+    defaultDelegatecallTargets[2] = v1_4_1_callOnly_canonical;
 
     // Set up the test hats
     uint256 signerHatCount = 5;


### PR DESCRIPTION
This PR disallows the safe signers from executing delegatecalls other than those to an owner-controlled set of approved target addresses. It establishes a default approved set that includes the safe multisend-call-only library addresses to support batch transactions a lá those enabled by the Safe and Den apps.

It also disallows delegatecalls altogether from HSG modules. Together with the restriction against directly calling the Safe, this prevents them from altering the Safe's state (eg to jailbreak HSG). 

An alternative approach would be to treat module executions exactly as we treat Safe executions, ie a) allow delegatecalls to approved targets, and b) apply the full guard pre-flight and post-flight checks to ensure that the relevant Safe state has not changed. We don't choose this approach because of the additional bytecode size and code complexity implications, as well as the fact that modules can apply batching themselves, ie bundle multiple `HSG.execTransactionFromModule` calls.

This PR also includes an update to use transient storage for the guard checks, resulting in significant gas savings.