### PR TITLE
Threshold module

### DIFF
--- a/gasreport.ansi
+++ b/gasreport.ansi
@@ -1,114 +1,35 @@
 No files changed, compilation skipped
 
-Ran 1 test for test/HatsSignerGate.t.sol:EnablingDelegatecallTargets
-[PASS] test_happy() (gas: 87415)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.23s (122.22ms CPU time)
-
 Ran 1 test for test/HatsSignerGate.t.sol:EnablingHSGModules
 [PASS] test_happy() (gas: 92382)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.23s (163.93ms CPU time)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.03s (97.60ms CPU time)
 
-Ran 1 test for test/HatsSignerGate.t.sol:DisablingHSGModules
-[PASS] test_happy() (gas: 66037)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.34s (113.25ms CPU time)
-
-Ran 1 test for test/HatsSignerGate.t.sol:DetachingHSG
-[PASS] test_happy() (gas: 91679)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.34s (113.02ms CPU time)
-
-Ran 1 test for test/HatsSignerGate.t.sol:DisablingDelegatecallTargets
-[PASS] test_happy() (gas: 60737)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.40s (61.56ms CPU time)
-
-Ran 2 tests for test/HatsSignerGate.t.sol:ClaimingSignerFor
-[PASS] test_happy() (gas: 307244)
-[PASS] test_happy_alreadyOwnerNotRegistered() (gas: 344229)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.61s (521.16ms CPU time)
-
-Ran 4 tests for test/HatsSignerGate.t.sol:AddingSigners
-[PASS] testAddSingleSigner() (gas: 257494)
-[PASS] testAddThreeSigners() (gas: 723836)
-[PASS] test_Multi_AddSingleSigner() (gas: 265415)
-[PASS] test_Multi_AddTwoSigners_DifferentHats() (gas: 503640)
-Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 3.28s (1.05s CPU time)
+Ran 1 test for test/HatsSignerGate.t.sol:ClaimingSigners
+[PASS] test_happy() (gas: 249354)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.15s (292.01ms CPU time)
 
 Ran 2 tests for test/HatsSignerGate.t.sol:SettingHSGGuard
 [PASS] test_happy() (gas: 90122)
 [PASS] test_removeGuard() (gas: 64266)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.14s (195.96ms CPU time)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.22s (280.98ms CPU time)
+
+Ran 2 tests for test/HatsSignerGate.t.sol:ClaimingSignerFor
+[PASS] test_happy() (gas: 307244)
+[PASS] test_happy_alreadyOwnerNotRegistered() (gas: 344229)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.52s (651.92ms CPU time)
+
+Ran 1 test for test/HatsSignerGate.t.sol:SettingOwnerHat
+[PASS] test_happy() (gas: 65585)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.92s (98.08ms CPU time)
+
+Ran 1 test for test/HatsSignerGate.t.sol:DisablingDelegatecallTargets
+[PASS] test_happy() (gas: 60737)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.12s (137.45ms CPU time)
 
 Ran 2 tests for test/HatsSignerGate.t.sol:ExecutingFromModuleReturnDataViaHSG
 [PASS] test_happy_executionFailure() (gas: 67193)
 [PASS] test_happy_executionSuccess() (gas: 104438)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.52s (291.71ms CPU time)
-
-Ran 1 test for test/HatsSignerGate.t.sol:ClaimingSigners
-[PASS] test_happy() (gas: 249354)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.22s (159.58ms CPU time)
-
-Ran 1 test for test/HatsSignerGate.t.sol:SettingOwnerHat
-[PASS] test_happy() (gas: 65585)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.07s (99.31ms CPU time)
-
-Ran 2 tests for test/HatsSignerGate.t.sol:GuardFunctionAuth
-[PASS] testCannotCallCheckAfterExecutionFromNonSafe() (gas: 34628)
-[PASS] testCannotCallCheckTransactionFromNonSafe() (gas: 38376)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 1.92s (237.73ms CPU time)
-
-Ran 2 tests for test/HatsSignerGate.t.sol:ExecutingFromModuleViaHSG
-[PASS] test_happy_executionFailure() (gas: 65776)
-[PASS] test_happy_executionSuccess() (gas: 103021)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.07s (221.40ms CPU time)
-
-Ran 1 test for test/HatsSignerGate.t.sol:HSGGuarding
-[PASS] test_executed() (gas: 445452)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.34s (89.78ms CPU time)
-
-Ran 7 tests for test/HatsSignerGate.t.sol:ConstrainingSigners
-[PASS] testCannotDecreaseThreshold() (gas: 1064871)
-[PASS] testCannotDisableGuard() (gas: 829846)
-[PASS] testCannotDisableModule() (gas: 846366)
-[PASS] testCannotIncreaseThreshold() (gas: 1064891)
-[PASS] testSignersCannotAddOwners() (gas: 1094851)
-[PASS] testSignersCannotRemoveOwners() (gas: 1077266)
-[PASS] testSignersCannotSwapOwners() (gas: 1099812)
-Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 7.24s (4.01s CPU time)
-
-Ran 1 test for test/HatsSignerGate.t.sol:SettingClaimableFor
-[PASS] test_happy(bool) (runs: 256, μ: 63840, ~: 65225)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 20.86s (19.50s CPU time)
-
-Ran 8 tests for test/HatsSignerGate.attacks.t.sol:AttacksScenarios
-[PASS] testAttackerCannotExploitSigHandlingDifferences() (gas: 1561059)
-[PASS] testCanClaimToReplaceInvalidSignerAtMaxSigner() (gas: 1442646)
-[PASS] testRemoveSignerCorrectlyUpdates() (gas: 1411795)
-[PASS] testSetTargetThresholdCannotSetBelowMinThreshold() (gas: 68786)
-[PASS] testSetTargetThresholdUpdatesThresholdCorrectly() (gas: 1381228)
-[PASS] testSignersCannotAddNewModules() (gas: 863416)
-[PASS] testSignersCannotReenterCheckTransactionToAddOwners() (gas: 1257108)
-[PASS] testTargetSigAttackFails() (gas: 1856994)
-Suite result: ok. 8 passed; 0 failed; 0 skipped; finished in 80.72s (7.84s CPU time)
-
-Ran 2 tests for test/HatsSignerGate.t.sol:Deployment
-[PASS] test_andSafe(bool,bool) (runs: 256, μ: 3068505, ~: 3073613)
-[PASS] test_onlyHSG(bool,bool) (runs: 256, μ: 2991875, ~: 2991386)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 80.72s (141.51s CPU time)
-
-Ran 3 tests for test/HatsSignerGate.t.sol:AddingSignerHats
-[PASS] test_Multi_NonOwnerCannotAddSignerHats() (gas: 58940)
-[PASS] test_Multi_OwnerCanAddSignerHats(uint256) (runs: 256, μ: 367318, ~: 108982)
-[PASS] test_Multi_OwnerCanAddSignerHats1() (gas: 85598)
-Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 116.09s (21.30s CPU time)
-
-Ran 7 tests for test/HatsSignerGate.t.sol:ExecutingTransactions
-[PASS] testExecByLessThanMinThresholdReverts() (gas: 866860)
-[PASS] testExecTxByHatWearers() (gas: 1206615)
-[PASS] testExecTxByNonHatWearersReverts() (gas: 1216340)
-[PASS] testExecTxByTooFewOwnersReverts() (gas: 456008)
-[PASS] test_Multi_ExecTxByHatWearers() (gas: 1230095)
-[PASS] test_Multi_ExecTxByNonHatWearersReverts() (gas: 1242053)
-[PASS] test_happy_delegateCall() (gas: 1234790)
-Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 113.85s (4.54s CPU time)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.32s (249.62ms CPU time)
 
 Ran 6 tests for test/HatsSignerGate.t.sol:RemovingSigners
 [PASS] testCanRemoveInvalidSigner1() (gas: 384833)
@@ -117,31 +38,110 @@ Ran 6 tests for test/HatsSignerGate.t.sol:RemovingSigners
 [PASS] testValidSignerCanClaimAfterPrevRemoved() (gas: 590931)
 [PASS] test_Multi_CanRemoveInvalidSigner1() (gas: 396104)
 [PASS] test_Multi_CannotRemoveValidSigner() (gas: 316219)
-Suite result: ok. 6 passed; 0 failed; 0 skipped; finished in 137.94s (2.68s CPU time)
+Suite result: ok. 6 passed; 0 failed; 0 skipped; finished in 4.52s (2.63s CPU time)
 
-Ran 2 tests for test/HatsSignerGate.t.sol:SettingThresholdConfig
-[PASS] test_happy_absolute(uint120,uint120,uint256) (runs: 256, μ: 1378082, ~: 1268231)
-[PASS] test_happy_proportional(uint120,uint120,uint256) (runs: 256, μ: 1338675, ~: 1270387)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 139.10s (273.40s CPU time)
+Ran 1 test for test/HatsSignerGate.t.sol:DisablingHSGModules
+[PASS] test_happy() (gas: 66037)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.30s (102.95ms CPU time)
 
-Ran 2 tests for test/HatsSignerGate.t.sol:MigratingHSG
-[PASS] test_happy_claimableFor_signersToMigrate(uint256) (runs: 256, μ: 1684111, ~: 1610362)
-[PASS] test_happy_noSignersToMigrate() (gas: 154022)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 148.27s (145.99s CPU time)
+Ran 2 tests for test/HatsSignerGate.t.sol:ExecutingFromModuleViaHSG
+[PASS] test_happy_executionFailure() (gas: 65776)
+[PASS] test_happy_executionSuccess() (gas: 103021)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.12s (201.55ms CPU time)
+
+Ran 7 tests for test/HatsSignerGate.t.sol:ConstrainingSigners
+[PASS] testCannotDecreaseThreshold() (gas: 1060562)
+[PASS] testCannotDisableGuard() (gas: 829957)
+[PASS] testCannotDisableModule() (gas: 845977)
+[PASS] testCannotIncreaseThreshold() (gas: 1060582)
+[PASS] testSignersCannotAddOwners() (gas: 1094447)
+[PASS] testSignersCannotRemoveOwners() (gas: 1076877)
+[PASS] testSignersCannotSwapOwners() (gas: 1099409)
+Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 6.60s (4.65s CPU time)
+
+Ran 7 tests for test/HatsSignerGate.t.sol:ExecutingTransactions
+[PASS] testExecByLessThanMinThresholdReverts() (gas: 866860)
+[PASS] testExecTxByHatWearers() (gas: 1206209)
+[PASS] testExecTxByNonHatWearersReverts() (gas: 1216340)
+[PASS] testExecTxByTooFewOwnersReverts() (gas: 456008)
+[PASS] test_Multi_ExecTxByHatWearers() (gas: 1229689)
+[PASS] test_Multi_ExecTxByNonHatWearersReverts() (gas: 1242053)
+[PASS] test_happy_delegateCall() (gas: 1233617)
+Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 6.68s (4.74s CPU time)
+
+Ran 1 test for test/HatsSignerGate.t.sol:EnablingDelegatecallTargets
+[PASS] test_happy() (gas: 87415)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.06s (80.15ms CPU time)
+
+Ran 1 test for test/HatsSignerGate.t.sol:DetachingHSG
+[PASS] test_happy() (gas: 91679)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.72s (86.10ms CPU time)
+
+Ran 2 tests for test/HatsSignerGate.t.sol:GuardFunctionAuth
+[PASS] testCannotCallCheckAfterExecutionFromNonSafe() (gas: 34628)
+[PASS] testCannotCallCheckTransactionFromNonSafe() (gas: 38376)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.16s (164.67ms CPU time)
+
+Ran 4 tests for test/HatsSignerGate.t.sol:AddingSigners
+[PASS] testAddSingleSigner() (gas: 257494)
+[PASS] testAddThreeSigners() (gas: 723836)
+[PASS] test_Multi_AddSingleSigner() (gas: 265415)
+[PASS] test_Multi_AddTwoSigners_DifferentHats() (gas: 503640)
+Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 2.92s (1.25s CPU time)
+
+Ran 1 test for test/HatsSignerGate.t.sol:HSGGuarding
+[PASS] test_executed() (gas: 445061)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.70s (87.56ms CPU time)
+
+Ran 1 test for test/HatsSignerGate.t.sol:SettingClaimableFor
+[PASS] test_happy(bool) (runs: 256, μ: 63840, ~: 65225)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 23.27s (21.32s CPU time)
+
+Ran 3 tests for test/HatsSignerGate.t.sol:AddingSignerHats
+[PASS] test_Multi_NonOwnerCannotAddSignerHats() (gas: 58940)
+[PASS] test_Multi_OwnerCanAddSignerHats(uint256) (runs: 256, μ: 340397, ~: 108982)
+[PASS] test_Multi_OwnerCanAddSignerHats1() (gas: 85598)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 23.53s (21.66s CPU time)
+
+Ran 2 tests for test/HatsSignerGate.t.sol:Deployment
+[PASS] test_andSafe(bool,bool) (runs: 256, μ: 3068505, ~: 3073613)
+[PASS] test_onlyHSG(bool,bool) (runs: 256, μ: 2991875, ~: 2991386)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 79.57s (139.20s CPU time)
+
+Ran 8 tests for test/HatsSignerGate.attacks.t.sol:AttacksScenarios
+[PASS] testAttackerCannotExploitSigHandlingDifferences() (gas: 1561059)
+[PASS] testCanClaimToReplaceInvalidSignerAtMaxSigner() (gas: 1442646)
+[PASS] testRemoveSignerCorrectlyUpdates() (gas: 1411795)
+[PASS] testSetTargetThresholdCannotSetBelowMinThreshold() (gas: 68786)
+[PASS] testSetTargetThresholdUpdatesThresholdCorrectly() (gas: 1381228)
+[PASS] testSignersCannotAddNewModules() (gas: 863026)
+[PASS] testSignersCannotReenterCheckTransactionToAddOwners() (gas: 1257330)
+[PASS] testTargetSigAttackFails() (gas: 1856994)
+Suite result: ok. 8 passed; 0 failed; 0 skipped; finished in 117.28s (8.04s CPU time)
 
 Ran 3 tests for test/HatsSignerGate.t.sol:ClaimingSignersFor
-[PASS] test_alreadyOwnerNotRegistered_happy(uint256) (runs: 256, μ: 1197472, ~: 1154308)
-[PASS] test_startingEmpty_happy(uint256) (runs: 256, μ: 1010038, ~: 976583)
-[PASS] test_startingWith1Signer_happy(uint256) (runs: 256, μ: 1084181, ~: 1053358)
-Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 145.28s (352.41s CPU time)
+[PASS] test_alreadyOwnerNotRegistered_happy(uint256) (runs: 256, μ: 1133836, ~: 960365)
+[PASS] test_startingEmpty_happy(uint256) (runs: 256, μ: 957382, ~: 816288)
+[PASS] test_startingWith1Signer_happy(uint256) (runs: 256, μ: 1031406, ~: 892919)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 148.19s (355.38s CPU time)
+
+Ran 2 tests for test/HatsSignerGate.t.sol:SettingThresholdConfig
+[PASS] test_happy_absolute(uint120,uint120,uint256) (runs: 256, μ: 1352011, ~: 1268171)
+[PASS] test_happy_proportional(uint120,uint120,uint256) (runs: 256, μ: 1315774, ~: 1270381)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 144.24s (279.63s CPU time)
+
+Ran 2 tests for test/HatsSignerGate.t.sol:MigratingHSG
+[PASS] test_happy_claimableFor_signersToMigrate(uint256) (runs: 256, μ: 1677198, ~: 1610362)
+[PASS] test_happy_noSignersToMigrate() (gas: 154022)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 151.92s (149.67s CPU time)
 | script/HatsSignerGate.s.sol:DeployImplementation contract |                 |         |         |         |         |
 |-----------------------------------------------------------|-----------------|---------|---------|---------|---------|
 | Deployment Cost                                           | Deployment Size |         |         |         |         |
-| 6107568                                                   | 28085           |         |         |         |         |
+| 6106214                                                   | 28079           |         |         |         |         |
 | Function Name                                             | min             | avg     | median  | max     | # calls |
 | hats                                                      | 400             | 400     | 400     | 400     | 63      |
 | prepare                                                   | 26507           | 26507   | 26507   | 26507   | 63      |
-| run                                                       | 4833404         | 4833404 | 4833404 | 4833404 | 63      |
+| run                                                       | 4832195         | 4832195 | 4832195 | 4832195 | 63      |
 | safeFallbackLibrary                                       | 346             | 346     | 346     | 346     | 63      |
 | safeMultisendLibrary                                      | 345             | 345     | 345     | 345     | 63      |
 | safeProxyFactory                                          | 347             | 347     | 347     | 347     | 63      |
@@ -165,12 +165,12 @@ Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 145.28s (352.41s CP
 | 0                                              | 0               |        |        |         |         |
 | Function Name                                  | min             | avg    | median | max     | # calls |
 | HATS                                           | 270             | 270    | 270    | 270     | 512     |
-| addSignerHats                                  | 23888           | 319400 | 70854  | 2270411 | 258     |
-| checkAfterExecution                            | 2568            | 11810  | 11189  | 20197   | 15      |
-| checkTransaction                               | 4016            | 57819  | 63287  | 76364   | 22      |
-| claimSigner                                    | 106076          | 114033 | 113180 | 129656  | 4411    |
+| addSignerHats                                  | 23888           | 293472 | 70854  | 2270411 | 258     |
+| checkAfterExecution                            | 2568            | 10849  | 10689  | 19695   | 15      |
+| checkTransaction                               | 4016            | 57900  | 63398  | 76364   | 22      |
+| claimSigner                                    | 106076          | 113932 | 113180 | 129656  | 4352    |
 | claimSignerFor                                 | 58676           | 83501  | 83501  | 108326  | 2       |
-| claimSignersFor                                | 26653           | 292574 | 260909 | 716320  | 1024    |
+| claimSignersFor                                | 26653           | 278818 | 260389 | 716320  | 1024    |
 | claimableFor                                   | 399             | 399    | 399    | 399     | 768     |
 | claimedSignerHats                              | 567             | 567    | 567    | 567     | 2       |
 | detachHSG                                      | 68435           | 68435  | 68435  | 68435   | 1       |
@@ -185,19 +185,19 @@ Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 145.28s (352.41s CP
 | getModulesPaginated                            | 2910            | 2910   | 2910   | 2910    | 512     |
 | implementation                                 | 435             | 435    | 435    | 435     | 512     |
 | isModuleEnabled                                | 660             | 660    | 660    | 660     | 3       |
-| isValidSigner                                  | 4135            | 4135   | 4135   | 4135    | 1338    |
+| isValidSigner                                  | 4135            | 4135   | 4135   | 4135    | 1332    |
 | locked                                         | 409             | 409    | 409    | 409     | 512     |
-| migrateToNewHSG                                | 114858          | 318430 | 311394 | 484146  | 257     |
+| migrateToNewHSG                                | 114858          | 317624 | 311394 | 484146  | 257     |
 | ownerHat                                       | 362             | 362    | 362    | 362     | 513     |
 | removeSigner                                   | 21708           | 65317  | 80325  | 85461   | 7       |
 | safe                                           | 425             | 425    | 425    | 425     | 829     |
 | setClaimableFor                                | 25038           | 27562  | 27838  | 27838   | 1282    |
 | setGuard                                       | 27088           | 42532  | 50254  | 50254   | 3       |
 | setOwnerHat                                    | 27674           | 27674  | 27674  | 27674   | 1       |
-| setThresholdConfig                             | 24305           | 77180  | 77160  | 90192   | 517     |
+| setThresholdConfig                             | 24305           | 76870  | 76879  | 90192   | 517     |
 | supportsInterface                              | 441             | 441    | 441    | 441     | 574     |
 | thresholdConfig                                | 899             | 901    | 899    | 2899    | 1796    |
-| validSignerCount                               | 7092            | 23514  | 20553  | 54491   | 1296    |
+| validSignerCount                               | 7092            | 22621  | 20553  | 54491   | 1296    |
 | validSignerHats                                | 505             | 505    | 505    | 505     | 2560    |
 
 
@@ -211,4 +211,4 @@ Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 145.28s (352.41s CP
 
 
 
-Ran 24 test suites in 148.70s (1022.80s CPU time): 63 tests passed, 0 failed, 0 skipped (63 total tests)
+Ran 24 test suites in 151.99s (737.08s CPU time): 63 tests passed, 0 failed, 0 skipped (63 total tests)

--- a/gasreport.ansi
+++ b/gasreport.ansi
@@ -1,173 +1,162 @@
-Compiling 56 files with Solc 0.8.28
-Solc 0.8.28 finished in 9.85s
-Compiler run successful!
+No files changed, compilation skipped
+
+Ran 1 test for test/HatsSignerGate.t.sol:EnablingDelegatecallTargets
+[PASS] test_happy() (gas: 87415)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.23s (122.22ms CPU time)
 
 Ran 1 test for test/HatsSignerGate.t.sol:EnablingHSGModules
 [PASS] test_happy() (gas: 92382)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.51s (100.60ms CPU time)
-
-Ran 1 test for test/HatsSignerGate.t.sol:DisablingDelegatecallTargets
-[PASS] test_happy() (gas: 60671)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.65s (187.04ms CPU time)
-
-Ran 1 test for test/HatsSignerGate.t.sol:ClaimingSigners
-[PASS] test_happy() (gas: 259360)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.65s (246.92ms CPU time)
-
-Ran 2 tests for test/HatsSignerGate.t.sol:SettingHSGGuard
-[PASS] test_happy() (gas: 90189)
-[PASS] test_removeGuard() (gas: 64311)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.73s (327.82ms CPU time)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.23s (163.93ms CPU time)
 
 Ran 1 test for test/HatsSignerGate.t.sol:DisablingHSGModules
-[PASS] test_happy() (gas: 65971)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.74s (92.87ms CPU time)
-
-Ran 1 test for test/HatsSignerGate.t.sol:EnablingDelegatecallTargets
-[PASS] test_happy() (gas: 87349)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.04s (90.48ms CPU time)
-
-Ran 1 test for test/HatsSignerGate.t.sol:SettingOwnerHat
-[PASS] test_happy() (gas: 65519)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.88s (95.92ms CPU time)
-
-Ran 3 tests for test/HatsSignerGate.t.sol:SettingMinThreshold
-[PASS] testNonOwnerCannotSetMinThreshold() (gas: 63875)
-[PASS] testSetInvalidMinThreshold() (gas: 60175)
-[PASS] testSetMinThreshold() (gas: 152228)
-Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 2.34s (392.20ms CPU time)
-
-Ran 2 tests for test/HatsSignerGate.t.sol:ExecutingFromModuleReturnDataViaHSG
-[PASS] test_happy_executionFailure() (gas: 67093)
-[PASS] test_happy_executionSuccess() (gas: 104380)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.58s (165.37ms CPU time)
-
-Ran 7 tests for test/HatsSignerGate.t.sol:ConstrainingSigners
-[PASS] testCannotDecreaseThreshold() (gas: 1138734)
-[PASS] testCannotDisableGuard() (gas: 862154)
-[PASS] testCannotDisableModule() (gas: 886216)
-[PASS] testCannotIncreaseThreshold() (gas: 1138732)
-[PASS] testSignersCannotAddOwners() (gas: 1177687)
-[PASS] testSignersCannotRemoveOwners() (gas: 1147242)
-[PASS] testSignersCannotSwapOwners() (gas: 1178745)
-Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 6.77s (4.42s CPU time)
+[PASS] test_happy() (gas: 66037)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.34s (113.25ms CPU time)
 
 Ran 1 test for test/HatsSignerGate.t.sol:DetachingHSG
-[PASS] test_happy() (gas: 91598)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.91s (89.09ms CPU time)
+[PASS] test_happy() (gas: 91679)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.34s (113.02ms CPU time)
 
-Ran 6 tests for test/HatsSignerGate.t.sol:RemovingSigners
-[PASS] testCanRemoveInvalidSigner1() (gas: 394799)
-[PASS] testCanRemoveInvalidSignerWhenMultipleSigners() (gas: 633859)
-[PASS] testCannotRemoveValidSigner() (gas: 314920)
-[PASS] testValidSignerCanClaimAfterPrevRemoved() (gas: 616922)
-[PASS] test_Multi_CanRemoveInvalidSigner1() (gas: 406095)
-[PASS] test_Multi_CannotRemoveValidSigner() (gas: 326114)
-Suite result: ok. 6 passed; 0 failed; 0 skipped; finished in 4.42s (2.43s CPU time)
-
-Ran 7 tests for test/HatsSignerGate.t.sol:ExecutingTransactions
-[PASS] testExecByLessThanMinThresholdReverts() (gas: 899010)
-[PASS] testExecTxByHatWearers() (gas: 1280454)
-[PASS] testExecTxByNonHatWearersReverts() (gas: 1278593)
-[PASS] testExecTxByTooFewOwnersReverts() (gas: 518330)
-[PASS] test_Multi_ExecTxByHatWearers() (gas: 1319956)
-[PASS] test_Multi_ExecTxByNonHatWearersReverts() (gas: 1320262)
-[PASS] test_happy_delegateCall() (gas: 1309501)
-Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 7.27s (4.85s CPU time)
-
-Ran 2 tests for test/HatsSignerGate.t.sol:ExecutingFromModuleViaHSG
-[PASS] test_happy_executionFailure() (gas: 65676)
-[PASS] test_happy_executionSuccess() (gas: 102963)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.18s (273.13ms CPU time)
-
-Ran 2 tests for test/HatsSignerGate.t.sol:GuardFunctionAuth
-[PASS] testCannotCallCheckAfterExecutionFromNonSafe() (gas: 34629)
-[PASS] testCannotCallCheckTransactionFromNonSafe() (gas: 38301)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.23s (197.47ms CPU time)
-
-Ran 1 test for test/HatsSignerGate.t.sol:HSGGuarding
-[PASS] test_executed() (gas: 462784)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.15s (74.16ms CPU time)
-
-Ran 8 tests for test/HatsSignerGate.attacks.t.sol:AttacksScenarios
-[PASS] testAttackerCannotExploitSigHandlingDifferences() (gas: 1701566)
-[PASS] testCanClaimToReplaceInvalidSignerAtMaxSigner() (gas: 1605408)
-[PASS] testRemoveSignerCorrectlyUpdates() (gas: 1567250)
-[PASS] testSetTargetThresholdUpdatesThresholdCorrectly() (gas: 1542809)
-[PASS] testSetTargetTresholdCannotSetBelowMinThreshold() (gas: 72112)
-[PASS] testSignersCannotAddNewModules() (gas: 903206)
-[PASS] testSignersCannotReenterCheckTransactionToAddOwners() (gas: 1340076)
-[PASS] testTargetSigAttackFails() (gas: 1964524)
-Suite result: ok. 8 passed; 0 failed; 0 skipped; finished in 9.51s (8.07s CPU time)
-
-Ran 4 tests for test/HatsSignerGate.t.sol:AddingSigners
-[PASS] testAddSingleSigner() (gas: 267433)
-[PASS] testAddThreeSigners() (gas: 766517)
-[PASS] test_Multi_AddSingleSigner() (gas: 275409)
-[PASS] test_Multi_AddTwoSigners_DifferentHats() (gas: 530103)
-Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 2.12s (1.20s CPU time)
-
-Ran 4 tests for test/HatsSignerGate.t.sol:SettingTargetThreshold
-[PASS] testNonOwnerHatWearerCannotSetTargetThreshold() (gas: 76489)
-[PASS] testSetTargetThreshold() (gas: 346012)
-[PASS] testSetTargetThreshold3of4() (gas: 1141589)
-[PASS] testSetTargetThreshold4of4() (gas: 1141574)
-Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 5.57s (2.21s CPU time)
-
-Ran 3 tests for test/HatsSignerGate.t.sol:AddingSignerHats
-[PASS] test_Multi_NonOwnerCannotAddSignerHats() (gas: 58896)
-[PASS] test_Multi_OwnerCanAddSignerHats(uint256) (runs: 256, μ: 372407, ~: 108961)
-[PASS] test_Multi_OwnerCanAddSignerHats1() (gas: 85577)
-Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 20.43s (18.12s CPU time)
-
-Ran 1 test for test/HatsSignerGate.t.sol:SettingClaimableFor
-[PASS] test_happy(bool) (runs: 257, μ: 63846, ~: 65225)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 16.52s (14.59s CPU time)
+Ran 1 test for test/HatsSignerGate.t.sol:DisablingDelegatecallTargets
+[PASS] test_happy() (gas: 60737)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.40s (61.56ms CPU time)
 
 Ran 2 tests for test/HatsSignerGate.t.sol:ClaimingSignerFor
-[PASS] test_happy() (gas: 319323)
-[PASS] test_happy_alreadyOwnerNotRegistered() (gas: 344162)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 23.67s (580.62ms CPU time)
+[PASS] test_happy() (gas: 307244)
+[PASS] test_happy_alreadyOwnerNotRegistered() (gas: 344229)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.61s (521.16ms CPU time)
+
+Ran 4 tests for test/HatsSignerGate.t.sol:AddingSigners
+[PASS] testAddSingleSigner() (gas: 257494)
+[PASS] testAddThreeSigners() (gas: 723836)
+[PASS] test_Multi_AddSingleSigner() (gas: 265415)
+[PASS] test_Multi_AddTwoSigners_DifferentHats() (gas: 503640)
+Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 3.28s (1.05s CPU time)
+
+Ran 2 tests for test/HatsSignerGate.t.sol:SettingHSGGuard
+[PASS] test_happy() (gas: 90122)
+[PASS] test_removeGuard() (gas: 64266)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.14s (195.96ms CPU time)
+
+Ran 2 tests for test/HatsSignerGate.t.sol:ExecutingFromModuleReturnDataViaHSG
+[PASS] test_happy_executionFailure() (gas: 67193)
+[PASS] test_happy_executionSuccess() (gas: 104438)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.52s (291.71ms CPU time)
+
+Ran 1 test for test/HatsSignerGate.t.sol:ClaimingSigners
+[PASS] test_happy() (gas: 249354)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.22s (159.58ms CPU time)
+
+Ran 1 test for test/HatsSignerGate.t.sol:SettingOwnerHat
+[PASS] test_happy() (gas: 65585)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.07s (99.31ms CPU time)
+
+Ran 2 tests for test/HatsSignerGate.t.sol:GuardFunctionAuth
+[PASS] testCannotCallCheckAfterExecutionFromNonSafe() (gas: 34628)
+[PASS] testCannotCallCheckTransactionFromNonSafe() (gas: 38376)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 1.92s (237.73ms CPU time)
+
+Ran 2 tests for test/HatsSignerGate.t.sol:ExecutingFromModuleViaHSG
+[PASS] test_happy_executionFailure() (gas: 65776)
+[PASS] test_happy_executionSuccess() (gas: 103021)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 2.07s (221.40ms CPU time)
+
+Ran 1 test for test/HatsSignerGate.t.sol:HSGGuarding
+[PASS] test_executed() (gas: 445452)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.34s (89.78ms CPU time)
+
+Ran 7 tests for test/HatsSignerGate.t.sol:ConstrainingSigners
+[PASS] testCannotDecreaseThreshold() (gas: 1064871)
+[PASS] testCannotDisableGuard() (gas: 829846)
+[PASS] testCannotDisableModule() (gas: 846366)
+[PASS] testCannotIncreaseThreshold() (gas: 1064891)
+[PASS] testSignersCannotAddOwners() (gas: 1094851)
+[PASS] testSignersCannotRemoveOwners() (gas: 1077266)
+[PASS] testSignersCannotSwapOwners() (gas: 1099812)
+Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 7.24s (4.01s CPU time)
+
+Ran 1 test for test/HatsSignerGate.t.sol:SettingClaimableFor
+[PASS] test_happy(bool) (runs: 256, μ: 63840, ~: 65225)
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 20.86s (19.50s CPU time)
+
+Ran 8 tests for test/HatsSignerGate.attacks.t.sol:AttacksScenarios
+[PASS] testAttackerCannotExploitSigHandlingDifferences() (gas: 1561059)
+[PASS] testCanClaimToReplaceInvalidSignerAtMaxSigner() (gas: 1442646)
+[PASS] testRemoveSignerCorrectlyUpdates() (gas: 1411795)
+[PASS] testSetTargetThresholdCannotSetBelowMinThreshold() (gas: 68786)
+[PASS] testSetTargetThresholdUpdatesThresholdCorrectly() (gas: 1381228)
+[PASS] testSignersCannotAddNewModules() (gas: 863416)
+[PASS] testSignersCannotReenterCheckTransactionToAddOwners() (gas: 1257108)
+[PASS] testTargetSigAttackFails() (gas: 1856994)
+Suite result: ok. 8 passed; 0 failed; 0 skipped; finished in 80.72s (7.84s CPU time)
 
 Ran 2 tests for test/HatsSignerGate.t.sol:Deployment
-[PASS] test_andSafe(bool,bool) (runs: 257, μ: 2942722, ~: 2947807)
-[PASS] test_onlyHSG(bool,bool) (runs: 257, μ: 2866151, ~: 2865660)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 64.50s (108.91s CPU time)
+[PASS] test_andSafe(bool,bool) (runs: 256, μ: 3068505, ~: 3073613)
+[PASS] test_onlyHSG(bool,bool) (runs: 256, μ: 2991875, ~: 2991386)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 80.72s (141.51s CPU time)
 
-Ran 3 tests for test/HatsSignerGate.t.sol:ClaimingSignersFor
-[PASS] test_alreadyOwnerNotRegistered_happy(uint256) (runs: 257, μ: 1126454, ~: 930870)
-[PASS] test_startingEmpty_happy(uint256) (runs: 257, μ: 1056134, ~: 853371)
-[PASS] test_startingWith1Signer_happy(uint256) (runs: 257, μ: 1131888, ~: 935133)
-Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 99.96s (244.00s CPU time)
+Ran 3 tests for test/HatsSignerGate.t.sol:AddingSignerHats
+[PASS] test_Multi_NonOwnerCannotAddSignerHats() (gas: 58940)
+[PASS] test_Multi_OwnerCanAddSignerHats(uint256) (runs: 256, μ: 367318, ~: 108982)
+[PASS] test_Multi_OwnerCanAddSignerHats1() (gas: 85598)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 116.09s (21.30s CPU time)
+
+Ran 7 tests for test/HatsSignerGate.t.sol:ExecutingTransactions
+[PASS] testExecByLessThanMinThresholdReverts() (gas: 866860)
+[PASS] testExecTxByHatWearers() (gas: 1206615)
+[PASS] testExecTxByNonHatWearersReverts() (gas: 1216340)
+[PASS] testExecTxByTooFewOwnersReverts() (gas: 456008)
+[PASS] test_Multi_ExecTxByHatWearers() (gas: 1230095)
+[PASS] test_Multi_ExecTxByNonHatWearersReverts() (gas: 1242053)
+[PASS] test_happy_delegateCall() (gas: 1234790)
+Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 113.85s (4.54s CPU time)
+
+Ran 6 tests for test/HatsSignerGate.t.sol:RemovingSigners
+[PASS] testCanRemoveInvalidSigner1() (gas: 384833)
+[PASS] testCanRemoveInvalidSignerWhenMultipleSigners() (gas: 597069)
+[PASS] testCannotRemoveValidSigner() (gas: 305003)
+[PASS] testValidSignerCanClaimAfterPrevRemoved() (gas: 590931)
+[PASS] test_Multi_CanRemoveInvalidSigner1() (gas: 396104)
+[PASS] test_Multi_CannotRemoveValidSigner() (gas: 316219)
+Suite result: ok. 6 passed; 0 failed; 0 skipped; finished in 137.94s (2.68s CPU time)
+
+Ran 2 tests for test/HatsSignerGate.t.sol:SettingThresholdConfig
+[PASS] test_happy_absolute(uint120,uint120,uint256) (runs: 256, μ: 1378082, ~: 1268231)
+[PASS] test_happy_proportional(uint120,uint120,uint256) (runs: 256, μ: 1338675, ~: 1270387)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 139.10s (273.40s CPU time)
 
 Ran 2 tests for test/HatsSignerGate.t.sol:MigratingHSG
-[PASS] test_happy_claimableFor_signersToMigrate(uint256) (runs: 257, μ: 1800323, ~: 1708508)
-[PASS] test_happy_noSignersToMigrate() (gas: 153969)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 103.31s (100.54s CPU time)
+[PASS] test_happy_claimableFor_signersToMigrate(uint256) (runs: 256, μ: 1684111, ~: 1610362)
+[PASS] test_happy_noSignersToMigrate() (gas: 154022)
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 148.27s (145.99s CPU time)
+
+Ran 3 tests for test/HatsSignerGate.t.sol:ClaimingSignersFor
+[PASS] test_alreadyOwnerNotRegistered_happy(uint256) (runs: 256, μ: 1197472, ~: 1154308)
+[PASS] test_startingEmpty_happy(uint256) (runs: 256, μ: 1010038, ~: 976583)
+[PASS] test_startingWith1Signer_happy(uint256) (runs: 256, μ: 1084181, ~: 1053358)
+Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 145.28s (352.41s CPU time)
 | script/HatsSignerGate.s.sol:DeployImplementation contract |                 |         |         |         |         |
 |-----------------------------------------------------------|-----------------|---------|---------|---------|---------|
 | Deployment Cost                                           | Deployment Size |         |         |         |         |
-| 5966005                                                   | 27424           |         |         |         |         |
+| 6107568                                                   | 28085           |         |         |         |         |
 | Function Name                                             | min             | avg     | median  | max     | # calls |
-| hats                                                      | 400             | 400     | 400     | 400     | 68      |
-| prepare                                                   | 26507           | 26507   | 26507   | 26507   | 68      |
-| run                                                       | 4700776         | 4700776 | 4700776 | 4700776 | 68      |
-| safeFallbackLibrary                                       | 346             | 346     | 346     | 346     | 68      |
-| safeMultisendLibrary                                      | 345             | 345     | 345     | 345     | 68      |
-| safeProxyFactory                                          | 347             | 347     | 347     | 347     | 68      |
-| safeSingleton                                             | 368             | 368     | 368     | 368     | 68      |
-| zodiacModuleFactory                                       | 346             | 346     | 346     | 346     | 68      |
+| hats                                                      | 400             | 400     | 400     | 400     | 63      |
+| prepare                                                   | 26507           | 26507   | 26507   | 26507   | 63      |
+| run                                                       | 4833404         | 4833404 | 4833404 | 4833404 | 63      |
+| safeFallbackLibrary                                       | 346             | 346     | 346     | 346     | 63      |
+| safeMultisendLibrary                                      | 345             | 345     | 345     | 345     | 63      |
+| safeProxyFactory                                          | 347             | 347     | 347     | 347     | 63      |
+| safeSingleton                                             | 368             | 368     | 368     | 368     | 63      |
+| zodiacModuleFactory                                       | 346             | 346     | 346     | 346     | 63      |
 
 
 | script/HatsSignerGate.s.sol:DeployInstance contract |                 |        |        |        |         |
 |-----------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                     | Deployment Size |        |        |        |         |
-| 1447213                                             | 6424            |        |        |        |         |
-| 1447213                                             | 6424            |        |        |        |         |
+| 1617977                                             | 7222            |        |        |        |         |
 | Function Name                                       | min             | avg    | median | max    | # calls |
-| prepare1                                            | 254403          | 365218 | 382510 | 382750 | 580     |
-| prepare2                                            | 46041           | 48819  | 48829  | 48829  | 580     |
-| run                                                 | 496118          | 754128 | 791423 | 898560 | 580     |
+| prepare1                                            | 233128          | 344872 | 361235 | 361475 | 575     |
+| prepare2                                            | 46041           | 48819  | 48829  | 48829  | 575     |
+| run                                                 | 472804          | 730519 | 768125 | 875289 | 575     |
 
 
 | src/HatsSignerGate.sol:HatsSignerGate contract |                 |        |        |         |         |
@@ -175,43 +164,41 @@ Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 103.31s (100.54s CP
 | Deployment Cost                                | Deployment Size |        |        |         |         |
 | 0                                              | 0               |        |        |         |         |
 | Function Name                                  | min             | avg    | median | max     | # calls |
-| HATS                                           | 315             | 315    | 315    | 315     | 512     |
-| addSignerHats                                  | 23866           | 324300 | 70832  | 2270389 | 258     |
-| checkAfterExecution                            | 2568            | 20851  | 23801  | 30451   | 15      |
-| checkTransaction                               | 3965            | 74980  | 79421  | 99813   | 22      |
-| claimSigner                                    | 115623          | 140907 | 131689 | 219102  | 1657    |
-| claimSignerFor                                 | 58654           | 89513  | 89513  | 120373  | 2       |
-| claimSignersFor                                | 5052            | 308276 | 247469 | 948539  | 1024    |
-| claimableFor                                   | 377             | 377    | 377    | 377     | 768     |
-| claimedSignerHats                              | 609             | 609    | 609    | 609     | 2       |
-| detachHSG                                      | 68398           | 68398  | 68398  | 68398   | 1       |
-| disableDelegatecallTarget                      | 30185           | 30185  | 30185  | 30185   | 1       |
-| disableModule                                  | 35471           | 35471  | 35471  | 35471   | 1       |
-| enableDelegatecallTarget                       | 47265           | 47265  | 47265  | 47265   | 2       |
-| enableModule                                   | 52446           | 52446  | 52446  | 52446   | 6       |
+| HATS                                           | 270             | 270    | 270    | 270     | 512     |
+| addSignerHats                                  | 23888           | 319400 | 70854  | 2270411 | 258     |
+| checkAfterExecution                            | 2568            | 11810  | 11189  | 20197   | 15      |
+| checkTransaction                               | 4016            | 57819  | 63287  | 76364   | 22      |
+| claimSigner                                    | 106076          | 114033 | 113180 | 129656  | 4411    |
+| claimSignerFor                                 | 58676           | 83501  | 83501  | 108326  | 2       |
+| claimSignersFor                                | 26653           | 292574 | 260909 | 716320  | 1024    |
+| claimableFor                                   | 399             | 399    | 399    | 399     | 768     |
+| claimedSignerHats                              | 567             | 567    | 567    | 567     | 2       |
+| detachHSG                                      | 68435           | 68435  | 68435  | 68435   | 1       |
+| disableDelegatecallTarget                      | 30207           | 30207  | 30207  | 30207   | 1       |
+| disableModule                                  | 35493           | 35493  | 35493  | 35493   | 1       |
+| enableDelegatecallTarget                       | 47287           | 47287  | 47287  | 47287   | 2       |
+| enableModule                                   | 52402           | 52402  | 52402  | 52402   | 6       |
 | enabledDelegatecallTargets                     | 589             | 589    | 589    | 589     | 1538    |
-| execTransactionFromModule                      | 24949           | 40680  | 40680  | 56411   | 2       |
-| execTransactionFromModuleReturnData            | 25901           | 41632  | 41632  | 57363   | 2       |
-| getGuard                                       | 417             | 417    | 417    | 417     | 515     |
-| getModulesPaginated                            | 2888            | 2888   | 2888   | 2888    | 512     |
-| implementation                                 | 413             | 413    | 413    | 413     | 512     |
+| execTransactionFromModule                      | 25003           | 40734  | 40734  | 56465   | 2       |
+| execTransactionFromModuleReturnData            | 25955           | 41686  | 41686  | 57417   | 2       |
+| getGuard                                       | 372             | 372    | 372    | 372     | 515     |
+| getModulesPaginated                            | 2910            | 2910   | 2910   | 2910    | 512     |
+| implementation                                 | 435             | 435    | 435    | 435     | 512     |
 | isModuleEnabled                                | 660             | 660    | 660    | 660     | 3       |
-| isValidSigner                                  | 4179            | 4179   | 4179   | 4179    | 1308    |
-| locked                                         | 387             | 387    | 387    | 387     | 512     |
-| migrateToNewHSG                                | 114827          | 299369 | 296377 | 466095  | 257     |
-| minThreshold                                   | 384             | 391    | 384    | 2384    | 515     |
+| isValidSigner                                  | 4135            | 4135   | 4135   | 4135    | 1338    |
+| locked                                         | 409             | 409    | 409    | 409     | 512     |
+| migrateToNewHSG                                | 114858          | 318430 | 311394 | 484146  | 257     |
 | ownerHat                                       | 362             | 362    | 362    | 362     | 513     |
-| removeSigner                                   | 21686           | 75365  | 89424  | 124367  | 7       |
-| safe                                           | 403             | 403    | 403    | 403     | 834     |
-| setClaimableFor                                | 25082           | 27608  | 27882  | 27882   | 1282    |
+| removeSigner                                   | 21708           | 65317  | 80325  | 85461   | 7       |
+| safe                                           | 425             | 425    | 425    | 425     | 829     |
+| setClaimableFor                                | 25038           | 27562  | 27838  | 27838   | 1282    |
 | setGuard                                       | 27088           | 42532  | 50254  | 50254   | 3       |
-| setMinThreshold                                | 23647           | 27101  | 25800  | 31856   | 3       |
-| setOwnerHat                                    | 27652           | 27652  | 27652  | 27652   | 1       |
-| setTargetThreshold                             | 23648           | 78006  | 61249  | 131475  | 10      |
-| supportsInterface                              | 441             | 441    | 441    | 441     | 579     |
-| targetThreshold                                | 383             | 394    | 383    | 2383    | 519     |
-| validSignerCount                               | 5595            | 23206  | 20531  | 56469   | 1296    |
-| validSignerHats                                | 548             | 548    | 548    | 548     | 2560    |
+| setOwnerHat                                    | 27674           | 27674  | 27674  | 27674   | 1       |
+| setThresholdConfig                             | 24305           | 77180  | 77160  | 90192   | 517     |
+| supportsInterface                              | 441             | 441    | 441    | 441     | 574     |
+| thresholdConfig                                | 899             | 901    | 899    | 2899    | 1796    |
+| validSignerCount                               | 7092            | 23514  | 20553  | 54491   | 1296    |
+| validSignerHats                                | 505             | 505    | 505    | 505     | 2560    |
 
 
 | test/mocks/TestGuard.sol:TestGuard contract |                 |     |        |     |         |
@@ -224,4 +211,4 @@ Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 103.31s (100.54s CP
 
 
 
-Ran 25 test suites in 103.38s (394.64s CPU time): 68 tests passed, 0 failed, 0 skipped (68 total tests)
+Ran 24 test suites in 148.70s (1022.80s CPU time): 63 tests passed, 0 failed, 0 skipped (63 total tests)

--- a/script/HatsSignerGate.s.sol
+++ b/script/HatsSignerGate.s.sol
@@ -87,8 +87,7 @@ contract DeployInstance is BaseScript {
 
   uint256 public ownerHat;
   uint256[] public signersHats;
-  uint256 public minThreshold;
-  uint256 public targetThreshold;
+  IHatsSignerGate.ThresholdConfig public thresholdConfig;
   address public safe;
   bool public locked;
   bool public claimableFor;
@@ -97,8 +96,7 @@ contract DeployInstance is BaseScript {
     address _implementation,
     uint256 _ownerHat,
     uint256[] memory _signersHats,
-    uint256 _minThreshold,
-    uint256 _targetThreshold,
+    IHatsSignerGate.ThresholdConfig memory _thresholdConfig,
     address _safe,
     bool _locked,
     bool _claimableFor,
@@ -108,8 +106,7 @@ contract DeployInstance is BaseScript {
     implementation = _implementation;
     ownerHat = _ownerHat;
     signersHats = _signersHats;
-    minThreshold = _minThreshold;
-    targetThreshold = _targetThreshold;
+    thresholdConfig = _thresholdConfig;
     safe = _safe;
     locked = _locked;
     claimableFor = _claimableFor;
@@ -139,8 +136,7 @@ contract DeployInstance is BaseScript {
       ownerHat: ownerHat,
       signerHats: signersHats,
       safe: safe,
-      minThreshold: minThreshold,
-      targetThreshold: targetThreshold,
+      thresholdConfig: thresholdConfig,
       locked: locked,
       claimableFor: claimableFor,
       implementation: implementation,

--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -211,7 +211,7 @@ contract HatsSignerGate is
         // for the first signer, check if the only owner is this contract and swap it out if so
         if (i == 0 && isInitialOwnersState) {
           addOwnerData = SafeManagerLib.encodeSwapOwnerAction(SafeManagerLib.SENTINELS, address(this), signer);
-        }  else {
+        } else {
           // otherwise, add the claimer as a new owner
           addOwnerData = SafeManagerLib.encodeAddOwnerWithThresholdAction(signer, threshold);
           newNumOnwers++;
@@ -222,7 +222,7 @@ contract HatsSignerGate is
       }
     }
 
-    // calculate the correct threshold 
+    // calculate the correct threshold
     uint256 newThreshold = _getCorrectThreshold(newNumOnwers);
     // the threshold cannot be higher than the number of owners
     if (newThreshold > newNumOnwers) newThreshold = newNumOnwers;
@@ -279,7 +279,7 @@ contract HatsSignerGate is
       newThreshold = owners.length;
     }
 
-    if (newThreshold != safe.getThreshold()){
+    if (newThreshold != safe.getThreshold()) {
       safe.execChangeThreshold(newThreshold);
     }
   }
@@ -392,7 +392,7 @@ contract HatsSignerGate is
     uint256 threshold = s.getThreshold();
 
     if (threshold != correctThreshold) revert InsufficientValidSignatures();
-    
+
     uint256 validSigCount = countValidSignatures(txHash, signatures, threshold);
 
     // revert if there aren't enough valid signatures

--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -240,7 +240,7 @@ contract HatsSignerGate is
     }
 
     // update the threshold if necessary
-    uint256 newThreshold = _getThreshold(newNumOnwers);
+    uint256 newThreshold = _getNewThreshold(newNumOnwers);
     if (newThreshold != threshold) {
       safe.execChangeThreshold(newThreshold);
     }
@@ -695,7 +695,7 @@ contract HatsSignerGate is
         addOwnerData = SafeManagerLib.encodeSwapOwnerAction(SafeManagerLib.SENTINELS, address(this), _signer);
       } else {
         // update the threshold
-        uint256 newThreshold = _getThreshold(owners.length + 1);
+        uint256 newThreshold = _getNewThreshold(owners.length + 1);
         // set up the addOwner call
         addOwnerData = SafeManagerLib.encodeAddOwnerWithThresholdAction(_signer, newThreshold);
       }
@@ -719,7 +719,7 @@ contract HatsSignerGate is
       removeOwnerData = SafeManagerLib.encodeSwapOwnerAction(SafeManagerLib.SENTINELS, _signer, address(this));
     } else {
       // update the threshold
-      uint256 newThreshold = _getThreshold(owners.length - 1);
+      uint256 newThreshold = _getNewThreshold(owners.length - 1);
 
       removeOwnerData =
         SafeManagerLib.encodeRemoveOwnerAction(SafeManagerLib.findPrevOwner(owners, _signer), _signer, newThreshold);
@@ -757,7 +757,7 @@ contract HatsSignerGate is
   /// owners
   /// @param numOwners The number of owners in the safe
   /// @return _threshold The safe's threshold
-  function _getThreshold(uint256 numOwners) internal view returns (uint256 _threshold) {
+  function _getNewThreshold(uint256 numOwners) internal view returns (uint256 _threshold) {
     // get the required amount of valid signatures according to the current number of owners and the threshold config
     _threshold = _getRequiredValidSignatures(numOwners);
     // the threshold cannot be higher than the number of owners

--- a/src/interfaces/IHatsSignerGate.sol
+++ b/src/interfaces/IHatsSignerGate.sol
@@ -189,7 +189,7 @@ interface IHatsSignerGate {
   /// {IHatsSignerGate.SetupParams}
   function setUp(bytes calldata initializeParams) external payable;
 
-  /// @notice Claims signer permissions for a valid wearer of `_hatId` on behalf of `_signer`.
+  /// @notice Claims signer permissions for the caller. Must be a valid wearer of `_hatId`.
   /// @dev If the `_signer` is not already an owner on the `safe`, they are added as a new owner.
   /// @param _hatId The hat id to claim signer rights for
   function claimSigner(uint256 _hatId) external;
@@ -210,11 +210,6 @@ interface IHatsSignerGate {
   /// @notice Removes an invalid signer from the `safe`, updating the threshold if appropriate
   /// @param _signer The address to remove if not a valid signer
   function removeSigner(address _signer) external;
-
-  /// @notice Tallies the number of existing `safe` owners that wear a signer hat and updates the `safe` threshold if
-  /// necessary
-  /// @dev Does NOT remove invalid `safe` owners
-  // function reconcileSignerCount() external;
 
   /// @notice Irreversibly locks the contract, preventing any further changes to the contract's settings.
   /// @dev Only callable by a wearer of the owner hat, and only if the contract is not locked.

--- a/test/HatsSignerGate.t.sol
+++ b/test/HatsSignerGate.t.sol
@@ -15,16 +15,6 @@ contract Deployment is TestSuite {
   // errors from dependencies
   error InvalidInitialization();
 
-  function assertCorrectModules(address[] memory _modules) public view {
-    (address[] memory pagedModules, address next) = hatsSignerGate.getModulesPaginated(SENTINELS, _modules.length);
-    assertEq(pagedModules.length, _modules.length);
-    for (uint256 i; i < _modules.length; ++i) {
-      // getModulesPaginated returns the modules in the reverse order they were added
-      assertEq(_modules[i], pagedModules[_modules.length - i - 1]);
-    }
-    assertEq(next, SENTINELS);
-  }
-
   function test_onlyHSG(bool _locked, bool _claimableFor) public {
     // deploy safe with this contract as the single owner
     address[] memory owners = new address[](1);
@@ -34,8 +24,7 @@ contract Deployment is TestSuite {
     hatsSignerGate = _deployHSG({
       _ownerHat: ownerHat,
       _signerHats: signerHats,
-      _minThreshold: minThreshold,
-      _targetThreshold: targetThreshold,
+      _thresholdConfig: thresholdConfig,
       _safe: address(testSafe),
       _expectedError: bytes4(0), // no expected error
       _locked: _locked,
@@ -47,8 +36,7 @@ contract Deployment is TestSuite {
 
     assertEq(hatsSignerGate.ownerHat(), ownerHat);
     assertValidSignerHats(signerHats);
-    assertEq(hatsSignerGate.minThreshold(), minThreshold);
-    assertEq(hatsSignerGate.targetThreshold(), targetThreshold);
+    assertEq(hatsSignerGate.thresholdConfig(), thresholdConfig);
     assertEq(address(hatsSignerGate.HATS()), address(hats));
     assertEq(address(hatsSignerGate.safe()), address(testSafe));
     assertEq(address(hatsSignerGate.implementation()), address(singletonHatsSignerGate));
@@ -62,8 +50,7 @@ contract Deployment is TestSuite {
     (hatsSignerGate, safe) = _deployHSGAndSafe({
       _ownerHat: ownerHat,
       _signerHats: signerHats,
-      _minThreshold: minThreshold,
-      _targetThreshold: targetThreshold,
+      _thresholdConfig: thresholdConfig,
       _locked: _locked,
       _claimableFor: _claimableFor,
       _hsgGuard: address(tstGuard),
@@ -73,8 +60,7 @@ contract Deployment is TestSuite {
 
     assertEq(hatsSignerGate.ownerHat(), ownerHat);
     assertValidSignerHats(signerHats);
-    assertEq(hatsSignerGate.minThreshold(), minThreshold);
-    assertEq(hatsSignerGate.targetThreshold(), targetThreshold);
+    assertEq(hatsSignerGate.thresholdConfig(), thresholdConfig);
     assertEq(address(hatsSignerGate.HATS()), address(hats));
     assertEq(address(hatsSignerGate.safe()), address(safe));
     assertEq(address(hatsSignerGate.implementation()), address(singletonHatsSignerGate));
@@ -88,9 +74,8 @@ contract Deployment is TestSuite {
   }
 
   function test_revert_reinitializeImplementation() public {
-    bytes memory initializeParams = abi.encode(
-      ownerHat, signerHats, address(safe), minThreshold, targetThreshold, false, address(singletonHatsSignerGate)
-    );
+    bytes memory initializeParams =
+      abi.encode(ownerHat, signerHats, address(safe), thresholdConfig, false, address(singletonHatsSignerGate));
     vm.expectRevert(InvalidInitialization.selector);
     singletonHatsSignerGate.setUp(initializeParams);
   }
@@ -143,51 +128,120 @@ contract AddingSignerHats is WithHSGInstanceTest {
   }
 }
 
-contract SettingTargetThreshold is WithHSGInstanceTest {
-  function testSetTargetThreshold() public {
-    _addSignersSameHat(1, signerHat);
+contract SettingThresholdConfig is WithHSGInstanceTest {
+  function test_happy_absolute(uint120 _min, uint120 _target, uint256 _signerCount) public {
+    vm.assume(_min > 0);
+    vm.assume(_target >= _min);
+    _signerCount = bound(_signerCount, 1, signerAddresses.length);
 
+    _addSignersSameHat(_signerCount, signerHat);
+
+    IHatsSignerGate.ThresholdConfig memory newConfig = IHatsSignerGate.ThresholdConfig({
+      thresholdType: IHatsSignerGate.TargetThresholdType.ABSOLUTE,
+      min: _min,
+      target: _target
+    });
+
+    vm.expectEmit();
+    emit IHatsSignerGate.ThresholdConfigSet(newConfig);
     vm.prank(owner);
-    vm.expectEmit(false, false, false, true);
-    emit IHatsSignerGate.TargetThresholdSet(3);
-    hatsSignerGate.setTargetThreshold(3);
+    hatsSignerGate.setThresholdConfig(newConfig);
 
-    assertEq(hatsSignerGate.targetThreshold(), 3);
+    assertEq(hatsSignerGate.thresholdConfig(), newConfig);
+
+    // check that the safe threshold was updated correctly
+    uint256 expectedThreshold = _signerCount < _target ? _signerCount : _target;
+    assertEq(safe.getThreshold(), expectedThreshold, "incorrect safe threshold");
+  }
+
+  function test_happy_proportional(uint120 _min, uint120 _target, uint256 _signerCount) public {
+    vm.assume(_min > 0);
+    vm.assume(_target < 10_000);
+    _signerCount = bound(_signerCount, 1, signerAddresses.length);
+
+    _addSignersSameHat(_signerCount, signerHat);
+
+    IHatsSignerGate.ThresholdConfig memory newConfig = IHatsSignerGate.ThresholdConfig({
+      thresholdType: IHatsSignerGate.TargetThresholdType.PROPORTIONAL,
+      min: _min,
+      target: _target
+    });
+
+    vm.expectEmit();
+    emit IHatsSignerGate.ThresholdConfigSet(newConfig);
+    vm.prank(owner);
+    hatsSignerGate.setThresholdConfig(newConfig);
+
+    assertEq(hatsSignerGate.thresholdConfig(), newConfig);
+
+    // check that the safe threshold was updated correctly
+    uint256 expectedThreshold = ((_signerCount * hatsSignerGate.thresholdConfig().target) + 9999) / 10_000;
+    assertEq(safe.getThreshold(), expectedThreshold, "incorrect safe threshold");
+  }
+
+  function test_revert_absolute_invalidConfig(uint120 _min, uint120 _target) public {
+    vm.assume(_min > 0);
+    // invalid condition
+    vm.assume(_target < _min);
+
+    IHatsSignerGate.ThresholdConfig memory invalidConfig = IHatsSignerGate.ThresholdConfig({
+      thresholdType: IHatsSignerGate.TargetThresholdType.ABSOLUTE,
+      min: _min,
+      target: _target
+    });
+
+    vm.expectRevert(IHatsSignerGate.InvalidThresholdConfig.selector);
+    vm.prank(owner);
+    hatsSignerGate.setThresholdConfig(invalidConfig);
+
     assertEq(safe.getThreshold(), 1);
   }
 
-  function testSetTargetThreshold3of4() public {
-    _addSignersSameHat(4, signerHat);
+  function test_revert_proportional_invalidConfig(uint120 _target) public {
+    vm.assume(_target > 10_000);
 
+    IHatsSignerGate.ThresholdConfig memory invalidConfig = IHatsSignerGate.ThresholdConfig({
+      thresholdType: IHatsSignerGate.TargetThresholdType.PROPORTIONAL,
+      min: 1,
+      target: _target
+    });
+
+    vm.expectRevert(IHatsSignerGate.InvalidThresholdConfig.selector);
     vm.prank(owner);
-    vm.expectEmit(false, false, false, true);
-    emit IHatsSignerGate.TargetThresholdSet(3);
+    hatsSignerGate.setThresholdConfig(invalidConfig);
 
-    hatsSignerGate.setTargetThreshold(3);
-
-    assertEq(hatsSignerGate.targetThreshold(), 3);
-    assertEq(safe.getThreshold(), 3);
+    assertEq(safe.getThreshold(), 1);
   }
 
-  function testSetTargetThreshold4of4() public {
-    _addSignersSameHat(4, signerHat);
+  function test_revert_invalidConfigType(uint8 _invalidType) public {
+    vm.assume(_invalidType > 1);
 
+    bytes memory invalidConfigBytes = abi.encodePacked(_invalidType, uint120(1), uint120(3));
+
+    bytes memory setThresholdConfigCallData =
+      abi.encodeWithSelector(hatsSignerGate.setThresholdConfig.selector, invalidConfigBytes);
+
+    vm.expectRevert(IHatsSignerGate.InvalidThresholdConfig.selector);
     vm.prank(owner);
-    vm.expectEmit(false, false, false, true);
-    emit IHatsSignerGate.TargetThresholdSet(4);
+    (bool success,) = address(hatsSignerGate).call(setThresholdConfigCallData);
+    assertFalse(success);
 
-    hatsSignerGate.setTargetThreshold(4);
-
-    assertEq(hatsSignerGate.targetThreshold(), 4);
-    assertEq(safe.getThreshold(), 4);
+    assertEq(safe.getThreshold(), 1);
   }
 
-  function testNonOwnerHatWearerCannotSetTargetThreshold() public {
+  function test_revert_notOwnerHatWearer() public {
+    IHatsSignerGate.ThresholdConfig memory newConfig = IHatsSignerGate.ThresholdConfig({
+      thresholdType: IHatsSignerGate.TargetThresholdType.ABSOLUTE,
+      min: 1,
+      target: 3
+    });
+
     vm.prank(other);
     vm.expectRevert(IHatsSignerGate.NotOwnerHatWearer.selector);
-    hatsSignerGate.setTargetThreshold(3);
+    hatsSignerGate.setThresholdConfig(newConfig);
 
-    assertEq(hatsSignerGate.targetThreshold(), 2);
+    assertEq(hatsSignerGate.thresholdConfig(), thresholdConfig);
+
     assertEq(safe.getThreshold(), 1);
   }
 
@@ -195,47 +249,17 @@ contract SettingTargetThreshold is WithHSGInstanceTest {
     vm.prank(owner);
     hatsSignerGate.lock();
 
-    vm.expectRevert(IHatsSignerGate.Locked.selector);
-    vm.prank(owner);
-    hatsSignerGate.setTargetThreshold(3);
-  }
-}
-
-contract SettingMinThreshold is WithHSGInstanceTest {
-  function testSetMinThreshold() public {
-    vm.prank(owner);
-    hatsSignerGate.setTargetThreshold(3);
-
-    vm.expectEmit(false, false, false, true);
-    emit IHatsSignerGate.MinThresholdSet(3);
-
-    vm.prank(owner);
-    hatsSignerGate.setMinThreshold(3);
-
-    assertEq(hatsSignerGate.minThreshold(), 3);
-  }
-
-  function testSetInvalidMinThreshold() public {
-    vm.prank(owner);
-    vm.expectRevert(IHatsSignerGate.InvalidMinThreshold.selector);
-    hatsSignerGate.setMinThreshold(3);
-  }
-
-  function testNonOwnerCannotSetMinThreshold() public {
-    vm.prank(other);
-    vm.expectRevert(IHatsSignerGate.NotOwnerHatWearer.selector);
-    hatsSignerGate.setMinThreshold(1);
-
-    assertEq(hatsSignerGate.minThreshold(), 2);
-  }
-
-  function test_revert_locked() public {
-    vm.prank(owner);
-    hatsSignerGate.lock();
+    IHatsSignerGate.ThresholdConfig memory newConfig = IHatsSignerGate.ThresholdConfig({
+      thresholdType: IHatsSignerGate.TargetThresholdType.ABSOLUTE,
+      min: 1,
+      target: 3
+    });
 
     vm.expectRevert(IHatsSignerGate.Locked.selector);
     vm.prank(owner);
-    hatsSignerGate.setMinThreshold(3);
+    hatsSignerGate.setThresholdConfig(newConfig);
+
+    assertEq(safe.getThreshold(), 1);
   }
 }
 
@@ -432,7 +456,6 @@ contract ExecutingTransactions is WithHSGInstanceTest {
     assertEq(address(safe).balance, postValue);
     assertEq(destAddress.balance, transferValue);
     assertEq(safe.nonce(), preNonce + 1);
-    // emit log_uint(address(safe).balance);
   }
 
   function testExecTxByNonHatWearersReverts() public {
@@ -919,8 +942,7 @@ contract MigratingHSG is WithHSGInstanceTest {
       address(singletonHatsSignerGate),
       ownerHat,
       signerHats,
-      minThreshold,
-      targetThreshold,
+      thresholdConfig,
       address(safe),
       false,
       false,

--- a/test/HatsSignerGate.t.sol
+++ b/test/HatsSignerGate.t.sol
@@ -166,8 +166,9 @@ contract SettingThresholdConfig is WithHSGInstanceTest {
 
     // check that the safe threshold was updated correctly
     uint256 expectedThreshold;
-    if (_signerCount > _target) {
-      expectedThreshold = _target;
+    uint256 target = hatsSignerGate.thresholdConfig().target;
+    if (_signerCount > target) {
+      expectedThreshold = target;
     } else {
       expectedThreshold = _signerCount;
     }

--- a/test/HatsSignerGate.t.sol
+++ b/test/HatsSignerGate.t.sol
@@ -150,7 +150,12 @@ contract SettingThresholdConfig is WithHSGInstanceTest {
     assertEq(hatsSignerGate.thresholdConfig(), newConfig);
 
     // check that the safe threshold was updated correctly
-    uint256 expectedThreshold = _signerCount < _target ? _signerCount : _target;
+    uint256 expectedThreshold;
+    if (_signerCount > _target) {
+      expectedThreshold = _target;
+    } else {
+      expectedThreshold = _signerCount;
+    }
     assertEq(safe.getThreshold(), expectedThreshold, "incorrect safe threshold");
   }
 
@@ -175,7 +180,13 @@ contract SettingThresholdConfig is WithHSGInstanceTest {
     assertEq(hatsSignerGate.thresholdConfig(), newConfig);
 
     // check that the safe threshold was updated correctly
-    uint256 expectedThreshold = ((_signerCount * hatsSignerGate.thresholdConfig().target) + 9999) / 10_000;
+    uint256 target = hatsSignerGate.thresholdConfig().target;
+    uint256 min = hatsSignerGate.thresholdConfig().min;
+    uint256 expectedThreshold = ((_signerCount * target) + 9999) / 10_000;
+    if (expectedThreshold < min) expectedThreshold = min;
+    if (expectedThreshold > _signerCount) {
+      expectedThreshold = _signerCount;
+    }
     assertEq(safe.getThreshold(), expectedThreshold, "incorrect safe threshold");
   }
 


### PR DESCRIPTION
This PR adds another threshold calculation logic - PROPORTIONAL threshold as a percentage of the number of owners in the Safe, in addition to the current ABSOLUTE threshold. Both of them define the required amount of valid signatures by owners of the safe in order to execute transactions.

Following this PR, the required amount of valid signatures is defined with the `ThresholdConfig`:
```solidity
/// @notice Struct for the threshold configuration
  /// @param thresholdType The type of target threshold, either ABSOLUTE or PROPORTIONAL
  /// @param min The minimum threshold
  /// @param target The target threshold
  struct ThresholdConfig {
    TargetThresholdType thresholdType;
    uint120 min;
    uint120 target;
  }
```
 It is set at deployment time and can be changed later by wearers of the HSG's owner hat. 

Here's how the config is then used to calculate the required amount of valid signatures:
```solidity
/// @dev Internal function to calculate the required amount of valid signatures according to the current number of
  /// owners in the safe and the threshold config
  /// @param numOwners The number of owners in the safe
  /// @return _requiredValidSignatures The required amount of valid signatures
  function _getRequiredValidSignatures(uint256 numOwners) internal view returns (uint256 _requiredValidSignatures) {
    // get the threshold config
    ThresholdConfig memory config = _thresholdConfig;

    // calculate the correct threshold
    if (config.thresholdType == TargetThresholdType.ABSOLUTE) {
      // ABSOLUTE
      if (numOwners < config.min) _requiredValidSignatures = config.min;
      else if (numOwners > config.target) _requiredValidSignatures = config.target;
      else _requiredValidSignatures = numOwners;
    } else {
      // PROPORTIONAL
      // add 9999 to round up
      _requiredValidSignatures = ((numOwners * config.target) + 9999) / 10_000;
      // ensure that the threshold is not lower than the min threshold
      if (_requiredValidSignatures < config.min) _requiredValidSignatures = config.min;
    }
  }
```

In both cases, the threshold is calculated based on the current amount of owners in the Safe, whether they are valid owners or not. This allows the HSG to maintain the invariant:
`threshold = Min(requiredValidSignatures, numOwners)`
Where `threshold` is the current Safe's threshold, `requiredValidSignatures` is  calculated by the absolute/proportional logic and `numOwners` is the Safe's current amount of owners.