### PR TITLE
Reentrancy checks

### DIFF
--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -413,6 +413,9 @@ contract HatsSignerGate is
     // ensure that the call is coming from the safe
     if (msg.sender != address(safe)) revert NotCalledFromSafe();
 
+    // prevent calling this function from execTransactionFromModule or execTransactionFromModuleReturnData
+    if (_reentrancyGuard == 1) revert NoReentryAllowed();
+
     // record the initial nonce of the safe at the beginning of the transaction
     if (_entrancyCounter == 0) {
       _initialNonce = safe.nonce() - 1;

--- a/test/HatsSignerGate.t.sol
+++ b/test/HatsSignerGate.t.sol
@@ -1263,7 +1263,7 @@ contract CheckTransaction is WithHSGHarnessInstanceTest {
       target, 0, new bytes(0), Enum.Operation.Call, 0, 0, 0, address(0), payable(0), signatures, address(0)
     );
 
-    _assertTransientStateVariables(1, Enum.Operation.Call, bytes32(0), 0, address(0));
+    _assertTransientStateVariables(Enum.Operation.Call, bytes32(0), 0, address(0), 0, safe.nonce() - 1, 1);
   }
 
   function test_revert_notCalledFromSafe() public callerIsSafe(false) {
@@ -1273,7 +1273,7 @@ contract CheckTransaction is WithHSGHarnessInstanceTest {
       address(0), 0, new bytes(0), Enum.Operation.Call, 0, 0, 0, address(0), payable(0), new bytes(0), address(0)
     );
 
-    _assertTransientStateVariables(0, Enum.Operation(uint8(0)), bytes32(0), 0, address(0));
+    _assertTransientStateVariables(Enum.Operation(uint8(0)), bytes32(0), 0, address(0), 0, 0, 0);
   }
 
   function test_revert_guardReverts() public callerIsSafe(true) {
@@ -1291,7 +1291,7 @@ contract CheckTransaction is WithHSGHarnessInstanceTest {
       address(0), 0, new bytes(0), Enum.Operation.Call, 0, 0, 0, address(0), payable(0), new bytes(0), address(0)
     );
 
-    _assertTransientStateVariables(0, Enum.Operation(uint8(0)), bytes32(0), 0, address(0));
+    _assertTransientStateVariables(Enum.Operation(uint8(0)), bytes32(0), 0, address(0), 0, 0, 0);
   }
 
   function test_delegatecallTargetEnabled() public callerIsSafe(true) {
@@ -1315,7 +1315,13 @@ contract CheckTransaction is WithHSGHarnessInstanceTest {
     );
 
     _assertTransientStateVariables(
-      1, Enum.Operation.DelegateCall, expectedOwnersHash, expectedThreshold, expectedFallbackHandler
+      Enum.Operation.DelegateCall,
+      expectedOwnersHash,
+      expectedThreshold,
+      expectedFallbackHandler,
+      0,
+      safe.nonce() - 1,
+      1
     );
   }
 
@@ -1337,7 +1343,7 @@ contract CheckTransaction is WithHSGHarnessInstanceTest {
       address(0)
     );
 
-    _assertTransientStateVariables(0, Enum.Operation(uint8(0)), bytes32(0), 0, address(0));
+    _assertTransientStateVariables(Enum.Operation(uint8(0)), bytes32(0), 0, address(0), 0, 0, 0);
   }
 
   function test_revert_cannotCallSafe() public callerIsSafe(true) {
@@ -1347,7 +1353,7 @@ contract CheckTransaction is WithHSGHarnessInstanceTest {
       address(safe), 0, new bytes(0), Enum.Operation.Call, 0, 0, 0, address(0), payable(0), new bytes(0), address(0)
     );
 
-    _assertTransientStateVariables(0, Enum.Operation(uint8(0)), bytes32(0), 0, address(0));
+    _assertTransientStateVariables(Enum.Operation(uint8(0)), bytes32(0), 0, address(0), 0, 0, 0);
   }
 
   function test_revert_thresholdTooLow(uint8 _operation) public callerIsSafe(true) {
@@ -1377,7 +1383,7 @@ contract CheckTransaction is WithHSGHarnessInstanceTest {
       target, 0, new bytes(0), operation, 0, 0, 0, address(0), payable(0), new bytes(0), address(0)
     );
 
-    _assertTransientStateVariables(0, Enum.Operation(uint8(0)), bytes32(0), 0, address(0));
+    _assertTransientStateVariables(Enum.Operation(uint8(0)), bytes32(0), 0, address(0), 0, 0, 0);
   }
 
   function test_revert_insufficientValidSignatures(uint8 _operation) public callerIsSafe(true) {
@@ -1408,7 +1414,7 @@ contract CheckTransaction is WithHSGHarnessInstanceTest {
       target, 0, new bytes(0), operation, 0, 0, 0, address(0), payable(0), signatures, address(0)
     );
 
-    _assertTransientStateVariables(0, Enum.Operation(uint8(0)), bytes32(0), 0, address(0));
+    _assertTransientStateVariables(Enum.Operation(uint8(0)), bytes32(0), 0, address(0), 0, 0, 0);
   }
 
   function test_revert_noReentryAllowed() public callerIsSafe(true) {
@@ -1483,12 +1489,6 @@ contract CheckAfterExecution is WithHSGHarnessInstanceTest {
 
     // call to checkAfterExecution should revert
     vm.expectRevert();
-    vm.prank(caller);
-    harness.exposed_checkAfterExecution(_txHash, _success);
-  }
-
-  function test_revert_notCalledFromSafe(bytes32 _txHash, bool _success) public callerIsSafe(false) {
-    vm.expectRevert(IHatsSignerGate.NotCalledFromSafe.selector);
     vm.prank(caller);
     harness.exposed_checkAfterExecution(_txHash, _success);
   }

--- a/test/SafeManagerLib.t.sol
+++ b/test/SafeManagerLib.t.sol
@@ -199,9 +199,11 @@ contract SafeManagerLib_DeployingSafeAndAttachingHSG is TestSuite {
       address(hats), address(singletonSafe), safeFallbackLibrary, safeMultisendLibrary, address(safeFactory)
     );
 
-    safe = ISafe(harness.deploySafeAndAttachHSG(
-      address(safeFactory), address(singletonSafe), safeFallbackLibrary, safeMultisendLibrary
-    ));
+    safe = ISafe(
+      harness.deploySafeAndAttachHSG(
+        address(safeFactory), address(singletonSafe), safeFallbackLibrary, safeMultisendLibrary
+      )
+    );
 
     assertTrue(safe.isModuleEnabled(address(harness)), "harness should be a module on the safe");
     assertEq(SafeManagerLib.getSafeGuard(safe), address(harness), "harness should be set as guard");

--- a/test/TestSuite.t.sol
+++ b/test/TestSuite.t.sol
@@ -1018,14 +1018,18 @@ contract WithHSGHarnessInstanceTest is TestSuite {
   }
 
   function _assertTransientStateVariables(
-    uint256 _guardEntries,
     Enum.Operation _operation,
     bytes32 _existingOwnersHash,
     uint256 _existingThreshold,
-    address _existingFallbackHandler
+    address _existingFallbackHandler,
+    uint256 _reentrancyGuard,
+    uint256 _initialNonce,
+    uint256 _entrancyCounter
   ) internal view {
-    assertEq(harness.guardEntries(), _guardEntries, "guard entries should be set");
     assertEq(uint8(harness.operation()), uint8(_operation), "operation should be set");
+    assertEq(harness.reentrancyGuard(), _reentrancyGuard, "reentrancy guard should be set");
+    assertEq(harness.initialNonce(), _initialNonce, "initial nonce should be set");
+    assertEq(harness.entrancyCounter(), _entrancyCounter, "entrancy counter should be set");
     if (_operation == Enum.Operation.DelegateCall) {
       assertEq(harness.existingOwnersHash(), _existingOwnersHash, "existing owners hash should be set");
       assertEq(harness.existingThreshold(), _existingThreshold, "existing threshold should be set");

--- a/test/harnesses/HatsSignerGateHarness.sol
+++ b/test/harnesses/HatsSignerGateHarness.sol
@@ -31,7 +31,9 @@ contract HatsSignerGateHarness is HatsSignerGate, SafeManagerLibHarness {
   uint256 public existingThreshold;
   address public existingFallbackHandler;
   Enum.Operation public operation;
-  uint256 public guardEntries;
+  uint256 public reentrancyGuard;
+  uint256 public initialNonce;
+  uint256 public entrancyCounter;
 
   /*//////////////////////////////////////////////////////////////
                         TRANSIENT STATE SETTERS
@@ -149,8 +151,16 @@ contract HatsSignerGateHarness is HatsSignerGate, SafeManagerLibHarness {
     return _operation;
   }
 
-  function exposed_guardEntries() public view returns (uint256) {
-    return _guardEntries;
+  function exposed_reentrancyGuard() public view returns (uint256) {
+    return _reentrancyGuard;
+  }
+
+  function exposed_initialNonce() public view returns (uint256) {
+    return _initialNonce;
+  }
+
+  function exposed_entrancyCounter() public view returns (uint256) {
+    return _entrancyCounter;
   }
 
   /// @dev Exposes the transient state variables set within checkTransaction
@@ -170,18 +180,17 @@ contract HatsSignerGateHarness is HatsSignerGate, SafeManagerLibHarness {
     checkTransaction(to, value, data, op, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, signatures, sender);
 
     // store the transient state in persistent storage for access in tests
-    guardEntries = _guardEntries;
     operation = _operation;
     existingOwnersHash = _existingOwnersHash;
     existingThreshold = _existingThreshold;
     existingFallbackHandler = _existingFallbackHandler;
+    reentrancyGuard = _reentrancyGuard;
+    initialNonce = _initialNonce;
+    entrancyCounter = _entrancyCounter;
   }
 
   /// @dev Allows tests to call checkAfterExecution by mocking the guardEntries transient state variable
   function exposed_checkAfterExecution(bytes32 _txHash, bool _success) public {
-    // force the guardEntries to be 1 as if it were set by checkTransaction
-    _guardEntries = 1;
-
     checkAfterExecution(_txHash, _success);
   }
 }


### PR DESCRIPTION
- Prevent calls to `checkTransaction` other than by the Safe
- Prevent reentrancy to `execTransactionFromModule` and `execTransactionFromModuleReturnData`
- Prevent entering `checkTransaction` from module execution