### PR TITLE
Fix/issue 8

### DIFF
--- a/src/lib/SafeManagerLib.sol
+++ b/src/lib/SafeManagerLib.sol
@@ -13,6 +13,13 @@ import { Enum, ISafe, IGuardManager, IModuleManager, IOwnerManager } from "../li
 /// @notice A library for managing Safe contract settings via a HatsSignerGate module
 library SafeManagerLib {
   /*//////////////////////////////////////////////////////////////
+                            CUSTOM ERRORS
+  //////////////////////////////////////////////////////////////*/
+
+  /// @notice Emitted when a call to the Safe's execTransactionFromModule fails
+  error SafeTransactionFailed();
+
+  /*//////////////////////////////////////////////////////////////
                               CONSTANTS
   //////////////////////////////////////////////////////////////*/
 
@@ -162,7 +169,10 @@ library SafeManagerLib {
 
   /// @dev Execute a transaction with `_data` from the context of a `_safe`
   function execSafeTransactionFromHSG(ISafe _safe, bytes memory _data) internal {
-    _safe.execTransactionFromModule({ to: address(_safe), value: 0, data: _data, operation: Enum.Operation.Call });
+    bool success =
+      _safe.execTransactionFromModule({ to: address(_safe), value: 0, data: _data, operation: Enum.Operation.Call });
+
+    if (!success) revert SafeTransactionFailed();
   }
 
   /// @dev Encode the action to disable HSG as a module when there are no other modules enabled on a `_safe`

--- a/test/HatsSignerGate.internals.t.sol
+++ b/test/HatsSignerGate.internals.t.sol
@@ -509,7 +509,8 @@ contract RemovingSignerInternals is WithHSGHarnessInstanceTest {
     vm.assume(uint256(_signerIndex) < fuzzingAddresses.length);
     address signer = fuzzingAddresses[_signerIndex];
 
-    // try to remove the signer, expecting tx success but nothing to change
+    // try to remove the signer, expecting a revert
+    vm.expectRevert(SafeManagerLib.SafeTransactionFailed.selector);
     harness.exposed_removeSigner(signer);
 
     assertEq(safe.getOwners().length, 1, "there should a single owner");

--- a/test/SafeManagerLib.t.sol
+++ b/test/SafeManagerLib.t.sol
@@ -106,6 +106,7 @@ contract SafeManagerLib_EncodingActions is Test {
 contract SafeManagerLib_ExecutingActions is WithHSGHarnessInstanceTest {
   /// @dev Since execSafeTransactionFromHSG is called by all the other exec* functions, we rely on tests for those
   /// functions to verify that execSafeTransactionFromHSG is working correctly.
+  // TODO: add test for execSafeTransactionFromHSG
 
   function test_execDisableHSGAsOnlyModule() public {
     harness.execDisableHSGAsOnlyModule(safe);
@@ -186,7 +187,8 @@ contract SafeManagerLib_ExecutingActions is WithHSGHarnessInstanceTest {
     vm.stopPrank();
 
     // attempt to change the threshold to a value greater than the number of owners
-    // the transaction will not revert, but the threshold will not be updated
+    // the transaction should revert
+    vm.expectRevert(SafeManagerLib.SafeTransactionFailed.selector);
     harness.execChangeThreshold(safe, _newThreshold);
 
     assertEq(safe.getThreshold(), 1, "threshold should not be updated");


### PR DESCRIPTION
This PR addresses [Sherlock issue 8](https://github.com/sherlock-audit/2024-11-hats-protocol-judging/blob/main/008.md) by reverting when calls from HSG to Safe.execTransactionFromModule fail. This prevents corner cases where Safe state and HSG state could get out of alignment. Such misalignment would be addressable via other means, but this is a cheap way to ensure that they never happen in the first place.