### PR TITLE
Fix/issue 19

### DIFF
--- a/src/HatsSignerGate.sol
+++ b/src/HatsSignerGate.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0
-pragma solidity >=0.8.13;
+pragma solidity >=0.8.28;
 
 // import { Test, console2 } from "../lib/forge-std/src/Test.sol"; // comment out after testing
 import { IHats } from "../lib/hats-protocol/src/Interfaces/IHats.sol";


### PR DESCRIPTION
This PR address [Sherlock issue 19](https://github.com/sherlock-audit/2024-11-hats-protocol-judging/blob/main/019.md), which identifies that HatsSignerGate.sol's pragma should be updated to reflect the minimum solc version that supports the `transient` keyword.