### PR TITLE
Add saltNonce to Safe deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,11 @@ jobs:
         with:
           version: nightly
 
+      - name: Check formatting
+        run: forge fmt --check
+
+      - name: Check contract sizes
+        run: forge build --sizes --skip script --via-ir
+
       - name: Run tests
         run: forge test -vvv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,10 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
-
-      - name: Check formatting
-        run: forge fmt --check
+      
+      # removed until transient keyword is supported
+      # - name: Check formatting
+      #   run: forge fmt --check
 
       - name: Check contract sizes
         run: forge build --sizes --skip script --via-ir

--- a/src/lib/SafeManagerLib.sol
+++ b/src/lib/SafeManagerLib.sol
@@ -48,7 +48,9 @@ library SafeManagerLib {
     address _safeFallbackLibrary,
     address _safeMultisendLibrary
   ) internal returns (address payable _safe) {
-    _safe = payable(SafeProxyFactory(_safeProxyFactory).createProxyWithNonce(_safeSingleton, hex"00", 0));
+    _safe = payable(
+      SafeProxyFactory(_safeProxyFactory).createProxyWithNonce(_safeSingleton, hex"00", uint256(uint160(address(this))))
+    );
 
     // Prepare calls to enable HSG as module and set it as guard
     bytes memory enableHSGModule = encodeEnableModuleAction(address(this));

--- a/test/TestSuite.t.sol
+++ b/test/TestSuite.t.sol
@@ -513,14 +513,14 @@ contract TestSuite is SafeTestHelpers {
                         CUSTOM ASSERTIONS
   //////////////////////////////////////////////////////////////*/
 
-  function assertValidSignerHats(uint256[] memory _signerHats) public view {
+  function assertValidSignerHats(HatsSignerGate _instance, uint256[] memory _signerHats) public view {
     for (uint256 i = 0; i < _signerHats.length; ++i) {
-      assertTrue(instance.isValidSignerHat(_signerHats[i]));
+      assertTrue(_instance.isValidSignerHat(_signerHats[i]));
     }
   }
 
-  function assertCorrectModules(address[] memory _modules) public view {
-    (address[] memory pagedModules, address next) = instance.getModulesPaginated(SENTINELS, _modules.length);
+  function assertCorrectModules(HatsSignerGate _instance, address[] memory _modules) public view {
+    (address[] memory pagedModules, address next) = _instance.getModulesPaginated(SENTINELS, _modules.length);
     assertEq(pagedModules.length, _modules.length);
     for (uint256 i; i < _modules.length; ++i) {
       // getModulesPaginated returns the modules in the reverse order they were added


### PR DESCRIPTION
This PR adds a non-zero salt nonce to the internal deployment of a new Safe proxy. This ensures that the deployment address of the Safe proxy contract is unique to the instance of HSG for which it is deployed.